### PR TITLE
feat: add ICT for most tools

### DIFF
--- a/clustering/K-NN/Shared-Memory-GPU/ict.yaml
+++ b/clustering/K-NN/Shared-Memory-GPU/ict.yaml
@@ -1,0 +1,83 @@
+author:
+- Mahdi Maghrebi
+citation: null
+contact: author@ict.com
+container: labshare/polus-knn-plugin:cuda-0.1.0
+description: K-Nearest Neighbors CUDA Code
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Input csv file containing the raw data
+  io_format:
+  - inputPath
+  io_type: path
+  name: inputPath
+  required: true
+- description: The desired number of Nearest Neighbors (NN) to be computed
+  io_format:
+  - K
+  io_type: number
+  name: K
+  required: true
+- description: The rate at which the sampling is conducted. The values closer to 1
+    provides more accurate results but the execution takes longer.
+  io_format:
+  - sampleRate
+  io_type: number
+  name: sampleRate
+  required: true
+- description: The threshold for the convergence
+  io_format:
+  - convThreshold
+  io_type: number
+  name: convThreshold
+  required: true
+name: labshare/K-NN(CUDA)
+outputs:
+- description: The full path to the output csv collections containing indices and
+    distances of K-NNs
+  io_format:
+  - outputPath
+  io_type: path
+  name: outputPath
+  required: true
+repository: https://github.com/polusai/image-tools
+specVersion: 1.0.0
+title: K-NN (CUDA)
+ui:
+- condition: null
+  customType: null
+  description: Name of the input CSV collection
+  ext: null
+  key: inputs.inputPath
+  title: The path to the input csv collection
+  ui_type: path
+- condition: null
+  customType: null
+  default: null
+  description: Insert an integer
+  integer: null
+  key: inputs.K
+  number_range: null
+  title: The desired number of Nearest Neighbors (NN) to be computed
+  ui_type: number
+- condition: null
+  customType: null
+  default: null
+  description: Insert a value between 0 and 1
+  integer: null
+  key: inputs.sampleRate
+  number_range: null
+  title: 'The sampling rate '
+  ui_type: number
+- condition: null
+  customType: null
+  default: null
+  description: Insert an integer. Smaller values result in more accurate solutions.
+  integer: null
+  key: inputs.convThreshold
+  number_range: null
+  title: The threshold for the convergence
+  ui_type: number
+version: 0.1.0

--- a/clustering/K-NN/Shared-Memory-Serial/ict.yaml
+++ b/clustering/K-NN/Shared-Memory-Serial/ict.yaml
@@ -1,0 +1,83 @@
+author:
+- Mahdi Maghrebi
+citation: null
+contact: author@ict.com
+container: labshare/polus-knn-plugin:serial-0.1.0
+description: K-Nearest Neighbors Serial Code
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Input csv file containing the raw data
+  io_format:
+  - inputPath
+  io_type: path
+  name: inputPath
+  required: true
+- description: The desired number of Nearest Neighbors (NN) to be computed
+  io_format:
+  - K
+  io_type: number
+  name: K
+  required: true
+- description: The rate at which the sampling is conducted. The values closer to 1
+    provides more accurate results but the execution takes longer.
+  io_format:
+  - sampleRate
+  io_type: number
+  name: sampleRate
+  required: true
+- description: The threshold for the convergence
+  io_format:
+  - convThreshold
+  io_type: number
+  name: convThreshold
+  required: true
+name: labshare/K-NN(Serial)
+outputs:
+- description: The full path to the output csv collections containing indices and
+    distances of K-NNs
+  io_format:
+  - outputPath
+  io_type: path
+  name: outputPath
+  required: true
+repository: https://github.com/polusai/image-tools
+specVersion: 1.0.0
+title: K-NN (Serial)
+ui:
+- condition: null
+  customType: null
+  description: Name of the input CSV collection
+  ext: null
+  key: inputs.inputPath
+  title: The path to the input csv collection
+  ui_type: path
+- condition: null
+  customType: null
+  default: null
+  description: Insert an integer
+  integer: null
+  key: inputs.K
+  number_range: null
+  title: The desired number of Nearest Neighbors (NN) to be computed
+  ui_type: number
+- condition: null
+  customType: null
+  default: null
+  description: Insert a value between 0 and 1
+  integer: null
+  key: inputs.sampleRate
+  number_range: null
+  title: 'The sampling rate '
+  ui_type: number
+- condition: null
+  customType: null
+  default: null
+  description: Insert an integer. Smaller values result in more accurate solutions.
+  integer: null
+  key: inputs.convThreshold
+  number_range: null
+  title: The threshold for the convergence
+  ui_type: number
+version: 0.1.0

--- a/clustering/k-means-clustering-tool/ict.yaml
+++ b/clustering/k-means-clustering-tool/ict.yaml
@@ -1,0 +1,123 @@
+author:
+- Jayapriya Nagarajan
+- Kelechi Nina
+- Hamdah Shafqat
+citation: null
+contact: jayapriya.nagarajan@nih.gov
+container: polusai/k-means-clustering-tool:0.3.5-dev0
+description: Cluster the data using K-Means.
+documentation: null
+entrypoint: python3 -m polus.images.clustering.k_means
+hardware: null
+inputs:
+- description: Input tabular data
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+- description: Pattern to parse input files
+  io_format:
+  - filePattern
+  io_type: string
+  name: filePattern
+  required: false
+- description: Select Manual or Elbow or Calinski Harabasz or Davies Bouldin methods
+  io_format:
+  - methods
+  io_type: string
+  name: methods
+  required: true
+- description: 'Enter minimum k-value:'
+  io_format:
+  - minimumRange
+  io_type: number
+  name: minimumRange
+  required: false
+- description: 'Enter maximum k-value:'
+  io_format:
+  - maximumRange
+  io_type: number
+  name: maximumRange
+  required: false
+- description: 'Number of clusters:'
+  io_format:
+  - numOfClus
+  io_type: number
+  name: numOfClus
+  required: false
+- description: Output a JSON preview of outputs produced by this plugin
+  io_format:
+  - preview
+  io_type: boolean
+  name: preview
+  required: false
+name: polusai/K-MeansClustering
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/polusai/polus-plugins
+specVersion: 1.0.0
+title: K-Means Clustering
+ui:
+- condition: null
+  customType: null
+  description: Input tabular data for clustering
+  ext: null
+  key: inputs.inpDir
+  title: Input tabular data
+  ui_type: path
+- condition: null
+  customType: null
+  default: null
+  description: Pattern to parse input files
+  key: inputs.filePattern
+  regex: null
+  title: FilePattern
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  description: Select Manual or Elbow or Calinski Harabasz or Davies Bouldin methods
+  fields:
+  - Manual
+  - Elbow
+  - CalinskiHarabasz
+  - DaviesBouldin
+  - default
+  key: inputs.methods
+  optional: null
+  title: Cluster data based on the methods selected to determine k-value
+  ui_type: select
+- condition: inputs.methods==DaviesBouldin
+  customType: null
+  default: null
+  description: 'Enter minimum k-value:'
+  integer: null
+  key: inputs.minimumRange
+  number_range: null
+  title: Enter minimum range
+  ui_type: number
+- condition: inputs.methods==DaviesBouldin
+  customType: null
+  default: null
+  description: 'Enter maximum k-value:'
+  integer: null
+  key: inputs.maximumRange
+  number_range: null
+  title: Enter maximum range
+  ui_type: number
+- condition: inputs.methods==Manual
+  customType: null
+  default: null
+  description: 'Number of clusters:'
+  integer: null
+  key: inputs.numOfClus
+  number_range: null
+  title: Enter number of clusters
+  ui_type: number
+version: 0.3.5-dev0

--- a/clustering/k-means-clustering-tool/plugin.json
+++ b/clustering/k-means-clustering-tool/plugin.json
@@ -3,7 +3,7 @@
   "version": "0.3.5-dev0",
   "title": "K-Means Clustering",
   "description": "Cluster the data using K-Means.",
-  "author": "Jayapriya Nagarajan (jayapriya.nagarajan@nih.gov), Kelechi Nina Mezu (nina.mezu@nih.gov) Hamdah Shafqat Abbasi (hamdahshafqat.abbasi@nih.gov)",
+  "author": "Jayapriya Nagarajan (jayapriya.nagarajan@nih.gov), Kelechi Nina Mezu (nina.mezu@nih.gov), Hamdah Shafqat Abbasi (hamdahshafqat.abbasi@nih.gov)",
   "institution": "National Center for Advancing Translational Sciences, National Institutes of Health",
   "repository": "https://github.com/polusai/polus-plugins",
   "website": "https://ncats.nih.gov/preclinical/core/informatics",
@@ -59,6 +59,12 @@
       "type": "number",
       "description": "Number of clusters:",
       "required": "false"
+    },
+    {
+      "name": "preview",
+      "type": "boolean",
+      "description": "Output a JSON preview of outputs produced by this plugin",
+      "required": "false"
     }
   ],
   "outputs": [
@@ -103,12 +109,6 @@
       "title": "Enter number of clusters",
       "description": "Number of clusters:",
       "condition": "model.inputs.methods==Manual"
-    },
-    {
-      "key": "inputs.fileExtension",
-      "title": "FileExtension",
-      "description": "Desired file format of an ouput file",
-      "default": ".arrow"
     }
   ]
 }

--- a/clustering/outlier-removal-tool/ict.yaml
+++ b/clustering/outlier-removal-tool/ict.yaml
@@ -1,0 +1,97 @@
+author:
+- Jayapriya Nagarajan
+citation: null
+contact: hamdahshafqat.abbasi@nih.gov
+container: polusai/outlier-removal-tool:0.2.7-dev0
+description: Remove outliers from the data.
+documentation: null
+entrypoint: python3 -m polus.images.clustering.outlier_removal
+hardware: null
+inputs:
+- description: Input tabular data.
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+- description: Filename pattern used to separate data.
+  io_format:
+  - filePattern
+  io_type: string
+  name: filePattern
+  required: false
+- description: Select methods for outlier removal
+  io_format:
+  - method
+  io_type: string
+  name: method
+  required: false
+- description: Select type of output file
+  io_format:
+  - outputType
+  io_type: string
+  name: outputType
+  required: false
+- description: Generate an output preview.
+  io_format:
+  - preview
+  io_type: boolean
+  name: preview
+  required: false
+name: polusai/OutlierRemoval
+outputs:
+- description: Output collection.
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/PolusAI/polus-plugins
+specVersion: 1.0.0
+title: Outlier Removal
+ui:
+- condition: null
+  customType: null
+  description: Input tabular data to be processed by this plugin.
+  ext: null
+  key: inputs.inpDir
+  title: Input tabular data
+  ui_type: path
+- condition: null
+  customType: null
+  default: null
+  description: Filename pattern used to separate data.
+  key: inputs.filePattern
+  regex: null
+  title: Filename pattern
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  description: Select method for outlier removal.
+  fields:
+  - IsolationForest
+  - IForest
+  key: inputs.method
+  optional: null
+  title: method
+  ui_type: select
+- condition: null
+  customType: null
+  description: Select output type.
+  fields:
+  - inlier
+  - outlier
+  - combined
+  key: inputs.outputType
+  optional: null
+  title: outputType
+  ui_type: select
+- condition: null
+  customType: null
+  default: null
+  description: Generate an output preview.
+  key: inputs.preview
+  title: Preview
+  ui_type: checkbox
+version: 0.2.7-dev0

--- a/clustering/outlier-removal-tool/plugin.json
+++ b/clustering/outlier-removal-tool/plugin.json
@@ -14,20 +14,23 @@
     "-m",
     "polus.images.clustering.outlier_removal"
   ],
-  "inputs": {
-    "inpDir": {
+  "inputs": [
+    {
+      "name": "inpDir",
       "type": "genericData",
       "title": "Input tabular data",
       "description": "Input tabular data.",
       "required": "True"
     },
-    "filePattern": {
+    {
+      "name": "filePattern",
       "type": "string",
       "title": "Filename pattern",
       "description": "Filename pattern used to separate data.",
       "required": "False"
     },
-    "method": {
+    {
+      "name": "method",
       "type": "enum",
       "title": "Methods",
       "description": "Select methods for outlier removal",
@@ -40,7 +43,8 @@
       },
       "required": "False"
     },
-    "outputType": {
+    {
+      "name": "outputType",
       "type": "enum",
       "title": "outputType",
       "description": "Select type of output file",
@@ -54,52 +58,59 @@
       },
       "required": "False"
     },
-    "preview": {
+    {
+      "name": "preview",
       "type": "boolean",
       "title": "Preview",
       "description": "Generate an output preview.",
       "required": "False"
     }
-  },
-  "outputs": {
-    "outDir": {
+  ],
+  "outputs": [
+    {
+      "name": "outDir",
       "type": "genericData",
       "description": "Output collection."
     }
-  },
-  "ui": {
-    "inpDir": {
+  ],
+  "ui": [
+    {
+      "key": "inputs.inpDir",
       "type": "genericData",
       "title": "Input tabular data",
       "description": "Input tabular data to be processed by this plugin.",
       "required": "True"
     },
-    "filePattern": {
+    {
+      "key": "inputs.filePattern",
       "type": "string",
       "title": "Filename pattern",
       "description": "Filename pattern used to separate data.",
       "required": "False",
       "default": ".*"
     },
-    "method": {
+    {
+      "key": "inputs.method",
       "type": "enum",
       "title": "method",
       "description": "Select method for outlier removal.",
       "required": "False",
       "default": "IsolationForest"
     },
-    "outputType": {
+    {
+      "key": "inputs.outputType",
       "type": "enum",
       "title": "outputType",
       "description": "Select output type.",
       "required": "False",
       "default": "inlier"
     },
-    "preview": {
+    {
+      "key": "inputs.preview",
       "type": "boolean",
       "title": "Preview",
       "description": "Generate an output preview.",
       "required": "False"
     }
-  }
+  ]
 }

--- a/clustering/polus-feature-subsetting-plugin/ict.yaml
+++ b/clustering/polus-feature-subsetting-plugin/ict.yaml
@@ -1,0 +1,168 @@
+author:
+- Gauhar Bains
+citation: null
+contact: gauhar.bains@labshare.org
+container: polusai/feature-subsetting-plugin:0.1.11
+description: Subset data using a given feature
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Input image collection to be processed by this plugin
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+- description: Filename pattern used to separate data
+  io_format:
+  - filePattern
+  io_type: string
+  name: filePattern
+  required: true
+- description: variables to group by in a section
+  io_format:
+  - groupVar
+  io_type: string
+  name: groupVar
+  required: true
+- description: variables to divide larger sections
+  io_format:
+  - sectionVar
+  io_type: string
+  name: sectionVar
+  required: false
+- description: CSV collection containing features
+  io_format:
+  - csvDir
+  io_type: path
+  name: csvDir
+  required: true
+- description: Feature to use to subset data
+  io_format:
+  - feature
+  io_type: string
+  name: feature
+  required: true
+- description: Percentile to remove
+  io_format:
+  - percentile
+  io_type: number
+  name: percentile
+  required: true
+- description: remove direction above or below percentile
+  io_format:
+  - removeDirection
+  io_type: string
+  name: removeDirection
+  required: true
+- description: Number of images to capture outside the cutoff
+  io_format:
+  - padding
+  io_type: string
+  name: padding
+  required: false
+- description: write output image collection or not
+  io_format:
+  - writeOutput
+  io_type: boolean
+  name: writeOutput
+  required: false
+name: polusai/FeatureSubsetting
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: Feature Subsetting
+ui:
+- condition: null
+  customType: null
+  description: Input image collection to be processed by this plugin
+  ext: null
+  key: inputs.inpDir
+  title: Input collection
+  ui_type: path
+- condition: null
+  customType: null
+  description: CSV collection containing features
+  ext: null
+  key: inputs.csvDir
+  title: CSV collection
+  ui_type: path
+- condition: null
+  customType: null
+  default: null
+  description: Feature to use to subset data
+  key: inputs.feature
+  regex: null
+  title: Feature
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  default: null
+  description: Percentile to remove
+  integer: null
+  key: inputs.percentile
+  number_range: null
+  title: Percentile
+  ui_type: number
+- condition: null
+  customType: null
+  description: remove direction above or below percentile
+  fields:
+  - Below
+  - Above
+  key: inputs.removeDirection
+  optional: null
+  title: Remove Direction
+  ui_type: select
+- condition: null
+  customType: null
+  default: null
+  description: Filename pattern used to separate data
+  key: inputs.filePattern
+  regex: null
+  title: Filename pattern
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  default: null
+  description: variables to group by in a section
+  key: inputs.groupVar
+  regex: null
+  title: Grouping Variables
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  default: null
+  description: variables to divide larger sections
+  key: inputs.sectionVar
+  regex: null
+  title: Section Variables
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  default: null
+  description: Number of images to capture outside the cutoff
+  key: inputs.padding
+  regex: null
+  title: Padding
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  default: null
+  description: write output image collection or not
+  key: inputs.writeOutput
+  title: Write Output
+  ui_type: checkbox
+version: 0.1.11

--- a/clustering/polus-hdbscan-clustering-plugin/ict.yaml
+++ b/clustering/polus-hdbscan-clustering-plugin/ict.yaml
@@ -1,0 +1,109 @@
+author:
+- Jayapriya Nagarajan
+citation: null
+contact: hythem.sidky@nih.gov
+container: polusai/hdbscan-clustering-plugin:0.4.7
+description: Cluster the data using HDBSCAN.
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Input CSV file collection
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+- description: Regular expression for optional row grouping.
+  io_format:
+  - groupingPattern
+  io_type: string
+  name: groupingPattern
+  required: false
+- description: Whether to average data across groups. Requires grouping pattern to
+    be defined.
+  io_format:
+  - averageGroups
+  io_type: boolean
+  name: averageGroups
+  required: false
+- description: Name of column containing labels. Required for grouping pattern.
+  io_format:
+  - labelCol
+  io_type: string
+  name: labelCol
+  required: false
+- description: Minimum cluster size
+  io_format:
+  - minClusterSize
+  io_type: number
+  name: minClusterSize
+  required: true
+- description: Increments outlier ID to 1
+  io_format:
+  - incrementOutlierId
+  io_type: boolean
+  name: incrementOutlierId
+  required: false
+name: polusai/HDBSCANClustering
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/PolusAI/polus-plugins
+specVersion: 1.0.0
+title: HDBSCAN Clustering
+ui:
+- condition: null
+  customType: null
+  description: Input csv file collection for clustering.
+  ext: null
+  key: inputs.inpDir
+  title: Input CSV file
+  ui_type: path
+- condition: null
+  customType: null
+  default: null
+  description: Regular expression for optional row grouping.
+  key: inputs.groupingPattern
+  regex: null
+  title: Grouping pattern
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  default: null
+  description: Whether to average data across groups. Requires grouping pattern to
+    be defined.
+  key: inputs.averageGroups
+  title: Group averaging
+  ui_type: checkbox
+- condition: null
+  customType: null
+  default: null
+  description: Name of column containing labels. Required for grouping pattern.
+  key: inputs.labelCol
+  regex: null
+  title: Label column
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  default: null
+  description: Minimum number of points in a cluster.
+  integer: null
+  key: inputs.minClusterSize
+  number_range: null
+  title: Minimum cluster size
+  ui_type: number
+- condition: null
+  customType: null
+  default: null
+  description: Set outlier ID to unity.
+  key: inputs.incrementOutlierId
+  title: Increment outlier ID
+  ui_type: checkbox
+version: 0.4.7

--- a/dimension_reduction/UMAP/Shared-Memory-GPU/ict.yaml
+++ b/dimension_reduction/UMAP/Shared-Memory-GPU/ict.yaml
@@ -1,0 +1,202 @@
+author:
+- Mahdi Maghrebi
+citation: null
+contact: author@ict.com
+container: labshare/polus-umap-cuda-plugin:0.1.0
+description: UMAP CUDA Code
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Input csv file containing the raw data
+  io_format:
+  - inputPath
+  io_type: path
+  name: inputPath
+  required: true
+- description: The desired number of Nearest Neighbors (NN) to be computed
+  io_format:
+  - K
+  io_type: number
+  name: K
+  required: true
+- description: The rate at which the sampling is conducted. The values closer to 1
+    provides more accurate results but the execution takes longer.
+  io_format:
+  - sampleRate
+  io_type: number
+  name: sampleRate
+  required: true
+- description: Dimension of the embedding space (usually 1-3)
+  io_format:
+  - DimLowSpace
+  io_type: number
+  name: DimLowSpace
+  required: true
+- description: The method for initialization of data in the embedding space
+  io_format:
+  - randomInitializing
+  io_type: boolean
+  name: randomInitializing
+  required: true
+- description: The number of training epochs
+  io_format:
+  - nEpochs
+  io_type: number
+  name: nEpochs
+  required: true
+- description: The variable that controls how tight (to each other) the data are placed
+    in the embedding space
+  io_format:
+  - minDist
+  io_type: number
+  name: minDist
+  required: true
+- description: The metric to compute the distance in the original space
+  io_format:
+  - distanceMetric
+  io_type: string
+  name: distanceMetric
+  required: true
+- description: The optional input needed for computation of some metrics
+  io_format:
+  - distanceV1
+  io_type: number
+  name: distanceV1
+  required: false
+- description: The optional input needed for computation of some metrics
+  io_format:
+  - distanceV2
+  io_type: number
+  name: distanceV2
+  required: false
+- description: The optional csv file representing a vector needed in computation of
+    some metrics
+  io_format:
+  - inputPathOptionalArray
+  io_type: path
+  name: inputPathOptionalArray
+  required: false
+name: labshare/UMAP(CUDA)
+outputs:
+- description: The full path to the output csv collection containing the coordinates
+    of data in the embedding space
+  io_format:
+  - outputPath
+  io_type: path
+  name: outputPath
+  required: true
+repository: https://github.com/polusai/image-tools
+specVersion: 1.0.0
+title: UMAP (CUDA)
+ui:
+- condition: null
+  customType: null
+  description: Insert the path to csv collection
+  ext: null
+  key: inputs.inputPath
+  title: Input CSV collection
+  ui_type: path
+- condition: null
+  customType: null
+  default: 15
+  description: Insert an integer
+  integer: null
+  key: inputs.K
+  number_range: null
+  title: The desired number of Nearest Neighbours (NN) in the original space to be
+    computed
+  ui_type: number
+- condition: null
+  customType: null
+  default: 0.9
+  description: Insert a value between 0 and 1
+  integer: null
+  key: inputs.sampleRate
+  number_range: null
+  title: Sampling Rate
+  ui_type: number
+- condition: null
+  customType: null
+  default: 2
+  description: Insert a value (usually 1-3)
+  integer: null
+  key: inputs.DimLowSpace
+  number_range: null
+  title: Dimension of the embedding space
+  ui_type: number
+- condition: null
+  customType: null
+  default: true
+  description: null
+  key: inputs.randomInitializing
+  title: Random initialization in the embedded space?
+  ui_type: checkbox
+- condition: null
+  customType: null
+  default: 500
+  description: Insert an integer (usually 200-500)
+  integer: null
+  key: inputs.nEpochs
+  number_range: null
+  title: The number of training epochs
+  ui_type: number
+- condition: null
+  customType: null
+  default: 0.01
+  description: Insert a value between 0 and 1
+  integer: null
+  key: inputs.minDist
+  number_range: null
+  title: min_dist
+  ui_type: number
+- condition: null
+  customType: null
+  description: Select the metric
+  fields:
+  - euclidean
+  - manhattan
+  - minkowski
+  - cosine
+  - correlation
+  - bray_curtis
+  - ll_dirichlet
+  - jaccard
+  - dice
+  - categorical_distance
+  - ordinal_distance
+  - count_distance
+  - levenshtein
+  - standardisedEuclidean
+  - weightedMinkowski
+  - mahalanobis
+  key: inputs.distanceMetric
+  optional: null
+  title: The metric to compute the distance in the original space
+  ui_type: select
+- condition: inputs.distanceV1==value
+  customType: null
+  default: null
+  description: Insert a value
+  integer: null
+  key: inputs.distanceV1
+  number_range: null
+  title: 'The optional input #1 needed for the chosen metric'
+  ui_type: number
+- condition: inputs.distanceV2==value
+  customType: null
+  default: null
+  description: Insert a value
+  integer: null
+  key: inputs.distanceV2
+  number_range: null
+  title: 'The optional input #2 needed for the chosen metric'
+  ui_type: number
+- condition: inputs.inputPathOptionalArray==value
+  customType: null
+  description: Insert the Path to csv collection
+  ext: null
+  key: inputs.inputPathOptionalArray
+  title: The optional csv collection representing a vector needed for the chosen metric
+  ui_type: path
+version: 0.1.0

--- a/dimension_reduction/UMAP/Shared-Memory-GPU/plugin.json
+++ b/dimension_reduction/UMAP/Shared-Memory-GPU/plugin.json
@@ -1,169 +1,169 @@
 {
-    "name": "UMAP (CUDA)",
-    "version": "0.1.0",
-    "title": "UMAP (CUDA)",
-    "description": "UMAP CUDA Code",
-    "author": "Mahdi Maghrebi",
-    "institution": "National Center for Advancing Translational Sciences, National Institutes of Health",
-    "containerId": "labshare/polus-umap-cuda-plugin:0.1.0",
-    "inputs": [
-        {
-            "name": "inputPath",
-            "type": "csvCollection",
-            "description": "Input csv file containing the raw data",
-            "required": "True"
-        },
-        {
-            "name": "K",
-            "type": "number",
-            "description": "The desired number of Nearest Neighbors (NN) to be computed",
-            "required": "True"
-        },
-        {
-            "name": "sampleRate",
-            "type": "number",
-            "description": "The rate at which the sampling is conducted. The values closer to 1 provides more accurate results but the execution takes longer.",
-            "required": "True"
-        },
-        {
-            "name": "DimLowSpace",
-            "type": "number",
-            "description": "Dimension of the embedding space (usually 1-3)",
-            "required": "True"
-        },
-        {
-            "name": "randomInitializing",
-            "type": "boolean",
-            "description": "The method for initialization of data in the embedding space",
-            "required": "True"
-        },
-        {
-            "name": "n_epochs",
-            "type": "number",
-            "description": "The number of training epochs",
-            "required": "True"
-        },
-        {
-            "name": "min_dist",
-            "type": "number",
-            "description": "The variable that controls how tight (to each other) the data are placed in the embedding space",
-            "required": "True"
-        },
-        {
-            "name": "distanceMetric",
-            "type": "enum",
-			"options": {
-				"values": [
-					"euclidean",
-                    "manhattan",
-  					"minkowski",
-                    "cosine",
-					"correlation",
-                    "bray_curtis",                                        
-					"ll_dirichlet",
-                    "jaccard",
-					"dice",
-                    "categorical_distance",
-					"ordinal_distance",
-                    "count_distance",                      
-					"levenshtein",
-                    "standardisedEuclidean",
-					"weightedMinkowski",
-                    "mahalanobis"  
-				]
-			},
-            "description": "The metric to compute the distance in the original space",
-            "required": "True"
-        },
-        {
-            "name": "distanceV1",
-            "type": "number",
-            "description": "The optional input needed for computation of some metrics",
-            "required": "False"
-        },
-        {
-            "name": "distanceV2",
-            "type": "number",
-            "description": "The optional input needed for computation of some metrics",
-            "required": "False"
-        },
-        {
-            "name": "inputPathOptionalArray",
-            "type": "csvCollection",
-            "description": "The optional csv file representing a vector needed in computation of some metrics",
-            "required": "False"
-        }
-    ],
-    "outputs": [
-        {
-            "name": "outputPath",
-            "type": "csvCollection",
-            "description": "The full path to the output csv collection containing the coordinates of data in the embedding space"
-        }
-    ],
-    "ui": [
-        {
-            "key": "inputs.inputPath",
-            "title": "Input CSV collection",
-            "description": "Insert the path to csv collection"
-        },
-        {
-            "key": "inputs.K",
-			"title": "The desired number of Nearest Neighbours (NN) in the original space to be computed",
-			"description": "Insert an integer",
-            "default": 15 			
-        },
-        {
-            "key": "inputs.sampleRate",
-            "title": "Sampling Rate",
-            "description": "Insert a value between 0 and 1",
-            "default": 0.9           
-        },
-        {
-            "key": "inputs.DimLowSpace",
-            "title": "Dimension of the embedding space",
-            "description": "Insert a value (usually 1-3)",
-            "default": 2          
-        },
-        {
-            "key": "inputs.randomInitializing",
-            "title": "Random initialization in the embedded space?",
-            "default": true
-        },
-        {
-            "key": "inputs.n_epochs",
-            "title": "The number of training epochs",
-            "description": "Insert an integer (usually 200-500)",
-            "default": 500
-        },
-        {
-            "key": "inputs.min_dist",
-            "title": "min_dist",
-            "description": "Insert a value between 0 and 1",
-            "default": 0.01
-        },
-        {
-            "key": "inputs.distanceMetric",
-            "title": "The metric to compute the distance in the original space",            
-            "description": "Select the metric"
-        },
-        {
-            "key": "inputs.distanceV1",
-            "title": "The optional input #1 needed for the chosen metric",      
-            "description": "Insert a value",
-            "condition": "model.inputs.distanceMetric==['weightedMinkowski','minkowski','ordinal_distance','count_distance','levenshtein']"        
-        },
-        {
-            "key": "inputs.distanceV2",
-            "title": "The optional input #2 needed for the chosen metric",  
-            "description": "Insert a value",
-            "condition": "model.inputs.distanceMetric==['count_distance','levenshtein']"           
-        },
-        {
-            "key": "inputs.inputPathOptionalArray",
-            "title": "The optional csv collection representing a vector needed for the chosen metric",
-            "description": "Insert the Path to csv collection",
-            "condition": "model.inputs.distanceMetric==['standardisedEuclidean','weightedMinkowski','mahalanobis']"
-        }
-    ]
+  "name": "UMAP (CUDA)",
+  "version": "0.1.0",
+  "title": "UMAP (CUDA)",
+  "description": "UMAP CUDA Code",
+  "author": "Mahdi Maghrebi",
+  "institution": "National Center for Advancing Translational Sciences, National Institutes of Health",
+  "containerId": "labshare/polus-umap-cuda-plugin:0.1.0",
+  "inputs": [
+    {
+      "name": "inputPath",
+      "type": "csvCollection",
+      "description": "Input csv file containing the raw data",
+      "required": "True"
+    },
+    {
+      "name": "K",
+      "type": "number",
+      "description": "The desired number of Nearest Neighbors (NN) to be computed",
+      "required": "True"
+    },
+    {
+      "name": "sampleRate",
+      "type": "number",
+      "description": "The rate at which the sampling is conducted. The values closer to 1 provides more accurate results but the execution takes longer.",
+      "required": "True"
+    },
+    {
+      "name": "DimLowSpace",
+      "type": "number",
+      "description": "Dimension of the embedding space (usually 1-3)",
+      "required": "True"
+    },
+    {
+      "name": "randomInitializing",
+      "type": "boolean",
+      "description": "The method for initialization of data in the embedding space",
+      "required": "True"
+    },
+    {
+      "name": "nEpochs",
+      "type": "number",
+      "description": "The number of training epochs",
+      "required": "True"
+    },
+    {
+      "name": "minDist",
+      "type": "number",
+      "description": "The variable that controls how tight (to each other) the data are placed in the embedding space",
+      "required": "True"
+    },
+    {
+      "name": "distanceMetric",
+      "type": "enum",
+      "options": {
+        "values": [
+          "euclidean",
+          "manhattan",
+          "minkowski",
+          "cosine",
+          "correlation",
+          "bray_curtis",
+          "ll_dirichlet",
+          "jaccard",
+          "dice",
+          "categorical_distance",
+          "ordinal_distance",
+          "count_distance",
+          "levenshtein",
+          "standardisedEuclidean",
+          "weightedMinkowski",
+          "mahalanobis"
+        ]
+      },
+      "description": "The metric to compute the distance in the original space",
+      "required": "True"
+    },
+    {
+      "name": "distanceV1",
+      "type": "number",
+      "description": "The optional input needed for computation of some metrics",
+      "required": "False"
+    },
+    {
+      "name": "distanceV2",
+      "type": "number",
+      "description": "The optional input needed for computation of some metrics",
+      "required": "False"
+    },
+    {
+      "name": "inputPathOptionalArray",
+      "type": "csvCollection",
+      "description": "The optional csv file representing a vector needed in computation of some metrics",
+      "required": "False"
+    }
+  ],
+  "outputs": [
+    {
+      "name": "outputPath",
+      "type": "csvCollection",
+      "description": "The full path to the output csv collection containing the coordinates of data in the embedding space"
+    }
+  ],
+  "ui": [
+    {
+      "key": "inputs.inputPath",
+      "title": "Input CSV collection",
+      "description": "Insert the path to csv collection"
+    },
+    {
+      "key": "inputs.K",
+      "title": "The desired number of Nearest Neighbours (NN) in the original space to be computed",
+      "description": "Insert an integer",
+      "default": 15
+    },
+    {
+      "key": "inputs.sampleRate",
+      "title": "Sampling Rate",
+      "description": "Insert a value between 0 and 1",
+      "default": 0.9
+    },
+    {
+      "key": "inputs.DimLowSpace",
+      "title": "Dimension of the embedding space",
+      "description": "Insert a value (usually 1-3)",
+      "default": 2
+    },
+    {
+      "key": "inputs.randomInitializing",
+      "title": "Random initialization in the embedded space?",
+      "default": true
+    },
+    {
+      "key": "inputs.nEpochs",
+      "title": "The number of training epochs",
+      "description": "Insert an integer (usually 200-500)",
+      "default": 500
+    },
+    {
+      "key": "inputs.minDist",
+      "title": "min_dist",
+      "description": "Insert a value between 0 and 1",
+      "default": 0.01
+    },
+    {
+      "key": "inputs.distanceMetric",
+      "title": "The metric to compute the distance in the original space",
+      "description": "Select the metric"
+    },
+    {
+      "key": "inputs.distanceV1",
+      "title": "The optional input #1 needed for the chosen metric",
+      "description": "Insert a value",
+      "condition": "model.inputs.distanceMetric==['weightedMinkowski','minkowski','ordinal_distance','count_distance','levenshtein']"
+    },
+    {
+      "key": "inputs.distanceV2",
+      "title": "The optional input #2 needed for the chosen metric",
+      "description": "Insert a value",
+      "condition": "model.inputs.distanceMetric==['count_distance','levenshtein']"
+    },
+    {
+      "key": "inputs.inputPathOptionalArray",
+      "title": "The optional csv collection representing a vector needed for the chosen metric",
+      "description": "Insert the Path to csv collection",
+      "condition": "model.inputs.distanceMetric==['standardisedEuclidean','weightedMinkowski','mahalanobis']"
+    }
+  ]
 }

--- a/features/feature-segmentation-eval-tool/ict.yaml
+++ b/features/feature-segmentation-eval-tool/ict.yaml
@@ -1,0 +1,106 @@
+author:
+- Vishakha Goyal
+- Hamdah Shafqat
+citation: null
+contact: vishakha.goyal@nih.gov
+container: polusai/feature-segmentation-eval-tool:0.2.6-dev0
+description: Plugin to generate evaluation metrics for feature comparison of ground
+  truth and predicted images.
+documentation: null
+entrypoint: python3 -m polus.images.features.feature_segmentation_eval
+hardware: null
+inputs:
+- description: Ground truth feature collection to be processed by this plugin.
+  io_format:
+  - GTDir
+  io_type: path
+  name: GTDir
+  required: true
+- description: Predicted feature collection to be processed by this plugin.
+  io_format:
+  - PredDir
+  io_type: path
+  name: PredDir
+  required: true
+- description: Filename pattern used to separate data.
+  io_format:
+  - filePattern
+  io_type: string
+  name: filePattern
+  required: false
+- description: Boolean to calculate number of bins for histogram by combining GT and
+    Predicted Labels.
+  io_format:
+  - combineLabels
+  io_type: boolean
+  name: combineLabels
+  required: false
+- description: Boolean to save output file as a single file.
+  io_format:
+  - singleOutFile
+  io_type: boolean
+  name: singleOutFile
+  required: false
+- description: Generate an output preview.
+  io_format:
+  - preview
+  io_type: boolean
+  name: preview
+  required: false
+name: polusai/FeatureSegmentationEval
+outputs:
+- description: Output collection.
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: Feature Segmentation Eval
+ui:
+- condition: null
+  customType: null
+  description: Ground truth feature collection to be processed by this plugin.
+  ext: null
+  key: inputs.GTDir
+  title: GTDir
+  ui_type: path
+- condition: null
+  customType: null
+  description: Predicted feature collection to be processed by this plugin.
+  ext: null
+  key: inputs.PredDir
+  title: PredDir
+  ui_type: path
+- condition: null
+  customType: null
+  default: null
+  description: Filename pattern used to separate data.
+  key: inputs.filePattern
+  regex: null
+  title: Filename pattern
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  default: null
+  description: Filename pattern used to separate data.
+  key: inputs.combineLabels
+  title: combineLabels
+  ui_type: checkbox
+- condition: null
+  customType: null
+  default: null
+  description: Boolean to save output file as a single file.
+  key: inputs.singleOutFile
+  title: singleOutFile
+  ui_type: checkbox
+- condition: null
+  customType: null
+  default: null
+  description: Generate an output preview.
+  key: inputs.preview
+  title: Preview example output of this plugin
+  ui_type: checkbox
+version: 0.2.6-dev0

--- a/features/nyxus-tool/ict.yaml
+++ b/features/nyxus-tool/ict.yaml
@@ -1,0 +1,157 @@
+author:
+- Nick Schaub
+- Hamdah Shafqat
+citation: null
+contact: nick.schaub@nih.gov
+container: polusai/nyxus-tool:0.1.7-dev0
+description: Nyxus plugin allows to make use of parallel pocessing for extracting
+  nyxus features
+documentation: null
+entrypoint: python3 -m polus.images.features.nyxus_plugin
+hardware: null
+inputs:
+- description: Collection containing intensity images
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+- description: Collection containing label images, i.e. groundtruth images
+  io_format:
+  - segDir
+  io_type: path
+  name: segDir
+  required: true
+- description: Filepattern to parse intensity images
+  io_format:
+  - intPattern
+  io_type: string
+  name: intPattern
+  required: true
+- description: Filepattern to parse label images
+  io_format:
+  - segPattern
+  io_type: string
+  name: segPattern
+  required: true
+- description: Features or feature groups to be extracted by nyxus plugin
+  io_format:
+  - features
+  io_type: array
+  name: features
+  required: false
+- description: Output file format
+  io_format:
+  - fileExtension
+  io_type: string
+  name: fileExtension
+  required: true
+- description: Pixel distance between neighboring cells
+  io_format:
+  - neighborDist
+  io_type: number
+  name: neighborDist
+  required: false
+- description: Pixel size in micrometer
+  io_format:
+  - pixelPerMicron
+  io_type: number
+  name: pixelPerMicron
+  required: false
+- description: Consider intensity image as single roi and ignoring segmentation mask
+  io_format:
+  - singleRoi
+  io_type: boolean
+  name: singleRoi
+  required: false
+name: polusai/Nyxusplugin
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/PolusAI/polus-plugins
+specVersion: 1.0.0
+title: Nyxus plugin
+ui:
+- condition: null
+  customType: null
+  description: Input image collection
+  ext: null
+  key: inputs.inpDir
+  title: inpDir
+  ui_type: path
+- condition: null
+  customType: null
+  description: Label image collection
+  ext: null
+  key: inputs.segDir
+  title: segDir
+  ui_type: path
+- condition: null
+  customType: null
+  default: null
+  description: Filepattern to parse intensity images
+  key: inputs.intPattern
+  regex: null
+  title: intPattern
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  default: null
+  description: Filepattern to parse label images
+  key: inputs.segPattern
+  regex: null
+  title: segPattern
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  default: null
+  description: Features or feature groups to be extracted by nyxus plugin
+  key: inputs.features
+  regex: null
+  title: features
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  description: Ouput file format
+  fields:
+  - .arrow
+  - .feather
+  - .csv
+  - default
+  key: inputs.fileExtension
+  optional: null
+  title: fileExtension
+  ui_type: select
+- condition: null
+  customType: null
+  default: 5
+  description: Pixel distance between neighboring cells
+  integer: null
+  key: inputs.neighborDist
+  number_range: null
+  title: neighborDist
+  ui_type: number
+- condition: null
+  customType: null
+  default: 1.0
+  description: Pixel size in micrometer
+  integer: null
+  key: inputs.pixelPerMicron
+  number_range: null
+  title: pixelPerMicron
+  ui_type: number
+- condition: null
+  customType: null
+  default: false
+  description: Consider intensity image as single roi and ignoring segmentation mask
+  key: inputs.singleRoi
+  title: singleRoi
+  ui_type: checkbox
+version: 0.1.7-dev0

--- a/features/nyxus-tool/plugin.json
+++ b/features/nyxus-tool/plugin.json
@@ -88,7 +88,7 @@
     {
       "name": "singleRoi",
       "description": "Consider intensity image as single roi and ignoring segmentation mask",
-      "type": "bool",
+      "type": "boolean",
       "options": null,
       "required": false
     }

--- a/features/pixel-segmentation-eval-tool/ict.yaml
+++ b/features/pixel-segmentation-eval-tool/ict.yaml
@@ -1,0 +1,108 @@
+author:
+- Vishakha Goyal
+citation: null
+contact: vishakha.goyal@nih.gov
+container: polusai/pixel-segmentation-eval-tool:0.1.12-dev0
+description: Plugin to generate evaluation metrics for pixel-wise comparison of ground
+  truth and predicted images.
+documentation: null
+entrypoint: python3 -m polus.images.features.pixel_segmentation_eval
+hardware: null
+inputs:
+- description: Ground truth input image collection to be processed by this plugin.
+  io_format:
+  - GTDir
+  io_type: path
+  name: GTDir
+  required: true
+- description: Predicted input image collection to be processed by this plugin.
+  io_format:
+  - PredDir
+  io_type: path
+  name: PredDir
+  required: true
+- description: Number of classes.
+  io_format:
+  - inputClasses
+  io_type: number
+  name: inputClasses
+  required: true
+- description: Filename pattern to filter data.
+  io_format:
+  - filePattern
+  io_type: string
+  name: filePattern
+  required: false
+- description: Boolean to create separate result file per image. Default is false.
+  io_format:
+  - individualStats
+  io_type: boolean
+  name: individualStats
+  required: false
+- description: Boolean to calculate overall statistics across all images. Default
+    is false.
+  io_format:
+  - totalStats
+  io_type: boolean
+  name: totalStats
+  required: false
+name: polusai/PixelSegmentationEval
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/polusai/polus-plugins
+specVersion: 1.0.0
+title: Pixel Segmentation Eval
+ui:
+- condition: null
+  customType: null
+  description: Ground truth input image collection to be processed by this plugin.
+  ext: null
+  key: inputs.GTDir
+  title: Ground Truth Images
+  ui_type: path
+- condition: null
+  customType: null
+  description: Predicted input image collection to be processed by this plugin.
+  ext: null
+  key: inputs.PredDir
+  title: Predicted Images
+  ui_type: path
+- condition: null
+  customType: null
+  default: null
+  description: Number of classes.
+  integer: null
+  key: inputs.inputClasses
+  number_range: null
+  title: Number of Classes
+  ui_type: number
+- condition: null
+  customType: null
+  default: null
+  description: Filename pattern to filter data.
+  key: inputs.filePattern
+  regex: null
+  title: Input filename pattern
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  default: null
+  description: Boolean to create separate result file per image. Default is false.
+  key: inputs.individualStats
+  title: Individual statistics
+  ui_type: checkbox
+- condition: null
+  customType: null
+  default: null
+  description: Boolean to calculate overall statistics across all images. Default
+    is false.
+  key: inputs.totalStats
+  title: Total statistics
+  ui_type: checkbox
+version: 0.1.12-dev0

--- a/features/polus-csv-statistics-plugin/ict.yaml
+++ b/features/polus-csv-statistics-plugin/ict.yaml
@@ -1,0 +1,81 @@
+author:
+- Nick Schaub
+citation: null
+contact: nick.schaub@nih.gov
+container: polusai/csv-statistics-plugin:0.2.1
+description: Calculate simple statistics to groups of data in a csv file.
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: The csv statistics to generate
+  io_format:
+  - statistics
+  io_type: array
+  name: statistics
+  required: true
+- description: Input csv collection to be processed by this plugin
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+- description: The filepattern of the images represented in the csv files
+  io_format:
+  - filePattern
+  io_type: string
+  name: filePattern
+  required: false
+- description: The variable(s) to group the images by
+  io_format:
+  - groupBy
+  io_type: string
+  name: groupBy
+  required: false
+name: polusai/CSVStatistics
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: CSV Statistics
+ui:
+- condition: null
+  customType: null
+  default: null
+  description: Types of statistics to calculate
+  key: inputs.statistics
+  regex: null
+  title: Statistics
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  description: Input csv collection to be processed by this plugin
+  ext: null
+  key: inputs.inpDir
+  title: Input collection
+  ui_type: path
+- condition: null
+  customType: null
+  default: null
+  description: The filepattern of the images represented in the csv files
+  key: inputs.filePattern
+  regex: null
+  title: Filepattern
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  default: null
+  description: The variable(s) to group the images by
+  key: inputs.groupBy
+  regex: null
+  title: Groupby Variables(s)
+  toolbar: null
+  ui_type: text
+version: 0.2.1

--- a/features/polus-feature-extraction-plugin/ict.yaml
+++ b/features/polus-feature-extraction-plugin/ict.yaml
@@ -1,0 +1,154 @@
+author:
+- Jayapriya Nagarajan
+citation: null
+contact: jayapriya.nagarajan@nih.gov
+container: polusai/feature-extraction-plugin:0.12.2
+description: Extract shape and intensity features from images.
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Labeled image collection
+  io_format:
+  - segDir
+  io_type: path
+  name: segDir
+  required: false
+- description: Intensity image collection
+  io_format:
+  - intDir
+  io_type: path
+  name: intDir
+  required: false
+- description: To match intensity and labeled/segmented image
+  io_format:
+  - filePattern
+  io_type: string
+  name: filePattern
+  required: true
+- description: Pixel distance to calculate the neighbors touching cells
+  io_format:
+  - pixelDistance
+  io_type: number
+  name: pixelDistance
+  required: false
+- description: Select features for extraction
+  io_format:
+  - features
+  io_type: array
+  name: features
+  required: true
+- description: 'csvfile : singlecsv for saving values in one csv file and separate
+    csv to save values for each image in separate csv file'
+  io_format:
+  - csvfile
+  io_type: string
+  name: csvfile
+  required: true
+- description: Use embedded pixel size
+  io_format:
+  - embeddedpixelsize
+  io_type: boolean
+  name: embeddedpixelsize
+  required: false
+- description: Unit name
+  io_format:
+  - unitLength
+  io_type: string
+  name: unitLength
+  required: false
+- description: Enter the number of pixels per unit of the metric
+  io_format:
+  - pixelsPerunit
+  io_type: number
+  name: pixelsPerunit
+  required: false
+name: polusai/FeatureExtraction
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: Feature Extraction
+ui:
+- condition: null
+  customType: null
+  description: Labeled image collection
+  ext: null
+  key: inputs.segDir
+  title: Label image collection
+  ui_type: path
+- condition: null
+  customType: null
+  description: Intensity image collection
+  ext: null
+  key: inputs.intDir
+  title: Intensity image collection
+  ui_type: path
+- condition: null
+  customType: null
+  default: null
+  description: To match intensity and labeled/segmented images
+  key: inputs.filePattern
+  regex: null
+  title: File pattern
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  default: null
+  description: Pixel distance to calculate the neighbors touching cells
+  integer: null
+  key: inputs.pixelDistance
+  number_range: null
+  title: Pixel Distance
+  ui_type: number
+- condition: null
+  customType: null
+  default: null
+  description: Select features
+  key: inputs.features
+  regex: null
+  title: Features
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  description: Save csv file separately for each image or one csv for all images
+  fields:
+  - singlecsv
+  - separatecsv
+  key: inputs.csvfile
+  optional: null
+  title: Output csv file
+  ui_type: select
+- condition: null
+  customType: null
+  default: true
+  description: Use embedded pixel size
+  key: inputs.embeddedpixelsize
+  title: Embedded pixel size
+  ui_type: checkbox
+- condition: inputs.embeddedpixelsize==false
+  customType: null
+  default: null
+  description: Unit name
+  key: inputs.unitLength
+  regex: null
+  title: Length of unit
+  toolbar: null
+  ui_type: text
+- condition: inputs.embeddedpixelsize==false
+  customType: null
+  default: null
+  description: Enter the number of pixels per unit of the metric
+  integer: null
+  key: inputs.pixelsPerunit
+  number_range: null
+  title: Pixels per unit
+  ui_type: number
+version: 0.12.2

--- a/features/polus-imagenet-model-featurization-plugin/ict.yaml
+++ b/features/polus-imagenet-model-featurization-plugin/ict.yaml
@@ -1,0 +1,79 @@
+author:
+- Hythem Sidky
+citation: null
+contact: hythem.sidky@axleinfo.com
+container: polusai/imagenet-model-featurization-plugin:0.1.3
+description: Image featurization using models pre-trained on ImageNet
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Input image collection to be processed by this plugin
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+- description: Pre-trained ImageNet model to use for featurization
+  io_format:
+  - model
+  io_type: string
+  name: model
+  required: true
+- description: Resolution to which the input images are scaled
+  io_format:
+  - resolution
+  io_type: string
+  name: resolution
+  required: true
+name: polusai/ImageNetModelFeaturization
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: ImageNet Model Featurization
+ui:
+- condition: null
+  customType: null
+  description: Input image collection to be processed by this plugin
+  ext: null
+  key: inputs.inpDir
+  title: Input collection
+  ui_type: path
+- condition: null
+  customType: null
+  description: Pre-trained ImageNet model to use for featurization
+  fields:
+  - Xception
+  - VGG16
+  - VGG19
+  - ResNet50
+  - ResNet101
+  - ResNet152
+  - ResNet50V2
+  - ResNet101V2
+  - ResNet152V2
+  - InceptionV3
+  - InceptionResNetV2
+  - DenseNet121
+  - DenseNet169
+  - DenseNet201
+  key: inputs.model
+  optional: null
+  title: Model
+  ui_type: select
+- condition: null
+  customType: null
+  default: null
+  description: Resolution to which the input images are scaled
+  key: inputs.resolution
+  regex: null
+  title: Image Resolution
+  toolbar: null
+  ui_type: text
+version: 0.1.3

--- a/features/polus-object-spectral-featurization-plugin/ict.yaml
+++ b/features/polus-object-spectral-featurization-plugin/ict.yaml
@@ -1,0 +1,79 @@
+author:
+- Hythem Sidky
+citation: null
+contact: hythem.sidky@axleinfo.com
+container: polusai/object-spectral-featurization-plugin:0.1.2
+description: Spectral feature generation for segmented objects.
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Input image collection to be processed by this plugin.
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+- description: Number of spectral features to compute.
+  io_format:
+  - numFeatures
+  io_type: number
+  name: numFeatures
+  required: true
+- description: Calculate scale invariant features.
+  io_format:
+  - scaleInvariant
+  io_type: boolean
+  name: scaleInvariant
+  required: true
+- description: Maximum number of faces for generated meshes.
+  io_format:
+  - limitMeshSize
+  io_type: number
+  name: limitMeshSize
+  required: false
+name: polusai/ObjectSpectralfeaturization
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: Object Spectral featurization
+ui:
+- condition: null
+  customType: null
+  description: Input image collection to be processed by this plugin.
+  ext: null
+  key: inputs.inpDir
+  title: Input collection
+  ui_type: path
+- condition: null
+  customType: null
+  default: null
+  description: Calculate scale invariant features.
+  key: inputs.scaleInvariant
+  title: Scale invariance
+  ui_type: checkbox
+- condition: null
+  customType: null
+  default: null
+  description: Number of spectral features to calculate.
+  integer: null
+  key: inputs.numFeatures
+  number_range: null
+  title: Number of features
+  ui_type: number
+- condition: null
+  customType: null
+  default: null
+  description: Maximum number of faces for generated meshes.
+  integer: null
+  key: inputs.limitMeshSize
+  number_range: null
+  title: Mesh size limit
+  ui_type: number
+version: 0.1.2

--- a/features/region-segmentation-eval-tool/ict.yaml
+++ b/features/region-segmentation-eval-tool/ict.yaml
@@ -1,0 +1,167 @@
+author:
+- Vishakha Goyal
+- Hamdah Shafqat
+citation: null
+contact: vishakha.goyal@nih.gov
+container: polusai/region-segmentation-eval-tool:0.2.5-dev0
+description: Plugin to generate evaluation metrics for region-wise comparison of ground
+  truth and predicted images.
+documentation: null
+entrypoint: python3 -m polus.images.features.region_segmentation_eval
+hardware: null
+inputs:
+- description: Ground truth input image collection to be processed by this plugin.
+  io_format:
+  - gtDir
+  io_type: path
+  name: gtDir
+  required: true
+- description: Predicted input image collection to be processed by this plugin.
+  io_format:
+  - predDir
+  io_type: path
+  name: predDir
+  required: true
+- description: Number of classes.
+  io_format:
+  - inputClasses
+  io_type: number
+  name: inputClasses
+  required: true
+- description: Boolean to calculate individual image statistics.Default is false.
+  io_format:
+  - individualData
+  io_type: boolean
+  name: individualData
+  required: false
+- description: Boolean to calculate summary of individual images.Default is false.
+  io_format:
+  - individualSummary
+  io_type: boolean
+  name: individualSummary
+  required: false
+- description: Boolean to calculate overall statistics across all images.Default is
+    false.
+  io_format:
+  - totalStats
+  io_type: boolean
+  name: totalStats
+  required: false
+- description: Boolean to calculate summary across all images.Default is false.
+  io_format:
+  - totalSummary
+  io_type: boolean
+  name: totalSummary
+  required: false
+- description: Importance of radius/diameter to find centroid distance. Should be
+    between (0,2]. Default is 0.5.
+  io_format:
+  - radiusFactor
+  io_type: string
+  name: radiusFactor
+  required: false
+- description: IoU theshold. Default is 0.
+  io_format:
+  - iouScore
+  io_type: string
+  name: iouScore
+  required: false
+- description: Filename pattern to filter data.
+  io_format:
+  - filePattern
+  io_type: string
+  name: filePattern
+  required: false
+name: polusai/RegionSegmentationEval
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/polusai/polus-plugins
+specVersion: 1.0.0
+title: Region Segmentation Eval
+ui:
+- condition: null
+  customType: null
+  description: Ground truth input image collection to be processed by this plugin.
+  ext: null
+  key: inputs.gtDir
+  title: Ground Truth Images
+  ui_type: path
+- condition: null
+  customType: null
+  description: Predicted input image collection to be processed by this plugin.
+  ext: null
+  key: inputs.predDir
+  title: Predicted Images
+  ui_type: path
+- condition: null
+  customType: null
+  default: null
+  description: Number of classes.
+  integer: null
+  key: inputs.inputClasses
+  number_range: null
+  title: Number of Classes
+  ui_type: number
+- condition: null
+  customType: null
+  default: null
+  description: Boolean to calculate individual image statistics.Default is false.
+  key: inputs.individualData
+  title: Individual Image Data
+  ui_type: checkbox
+- condition: null
+  customType: null
+  default: null
+  description: Boolean to calculate summary of individual images.Default is false.
+  key: inputs.individualSummary
+  title: Individual Image Summary
+  ui_type: checkbox
+- condition: null
+  customType: null
+  default: null
+  description: Boolean to calculate overall statistics across all images.Default is
+    false.
+  key: inputs.totalStats
+  title: Total Statistics
+  ui_type: checkbox
+- condition: null
+  customType: null
+  default: null
+  description: Boolean to calculate summary across all images.Default is false.
+  key: inputs.totalSummary
+  title: Summary for all Images
+  ui_type: checkbox
+- condition: null
+  customType: null
+  default: null
+  description: Importance of radius/diameter to find centroid distance. Should be
+    between (0,2]. Default is 0.5.
+  key: inputs.radiusFactor
+  regex: null
+  title: Radius Factor
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  default: null
+  description: IoU theshold. Default is 0.
+  key: inputs.iouScore
+  regex: null
+  title: IoU Score
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  default: null
+  description: Filename pattern to filter data.
+  key: inputs.filePattern
+  regex: null
+  title: FilePattern
+  toolbar: null
+  ui_type: text
+version: 0.2.5-dev0

--- a/features/region-segmentation-eval-tool/plugin.json
+++ b/features/region-segmentation-eval-tool/plugin.json
@@ -3,7 +3,7 @@
   "version": "0.2.5-dev0",
   "title": "Region Segmentation Eval",
   "description": "Plugin to generate evaluation metrics for region-wise comparison of ground truth and predicted images.",
-  "author": "Vishakha Goyal (vishakha.goyal@nih.gov), Hamdah Shafqat Abbasi (hamdahshafqat.abbasi@nih.gov),",
+  "author": "Vishakha Goyal (vishakha.goyal@nih.gov), Hamdah Shafqat Abbasi (hamdahshafqat.abbasi@nih.gov)",
   "institution": "National Center for Advancing Translational Sciences, National Institutes of Health",
   "repository": "https://github.com/polusai/polus-plugins",
   "website": "https://ncats.nih.gov/preclinical/core/informatics",

--- a/formats/arrow-to-tabular-tool/ict.yaml
+++ b/formats/arrow-to-tabular-tool/ict.yaml
@@ -1,0 +1,54 @@
+author:
+- Kelechi Nina
+- Hamdah Shafqat
+citation: null
+contact: nina.mezu@nih.gov
+container: polusai/arrow-to-tabular-tool:0.2.3-dev0
+description: WIPP plugin to converts Arrow file format to Tabular Data.
+documentation: null
+entrypoint: python3 -m polus.images.formats.arrow_to_tabular
+hardware: null
+inputs:
+- description: Output file type to convert from feather file
+  io_format:
+  - fileFormat
+  io_type: string
+  name: fileFormat
+  required: true
+- description: Input image collection to be processed by this plugin
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+name: polusai/ArrowtoTabular
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/PolusAI/polus-plugins
+specVersion: 1.0.0
+title: Arrow to Tabular
+ui:
+- condition: null
+  customType: null
+  description: 'Output file type to convert from feather file. ex: .parquet or .csv'
+  fields:
+  - .csv
+  - .parquet
+  - default
+  key: inputs.fileFormat
+  optional: null
+  title: Filename pattern
+  ui_type: select
+- condition: null
+  customType: null
+  description: Input generic data collection to be processed by this plugin
+  ext: null
+  key: inputs.inpDir
+  title: Input collection
+  ui_type: path
+version: 0.2.3-dev0

--- a/formats/file-renaming-tool/ict.yaml
+++ b/formats/file-renaming-tool/ict.yaml
@@ -1,0 +1,84 @@
+author:
+- Melanie Parham
+- Hamdah Shafqat
+citation: null
+contact: melanie.parham@axleinfo.com
+container: polusai/file-renaming-tool:0.2.4-dev0
+description: Rename and store image collection files in a new image collection
+documentation: null
+entrypoint: python3 -m polus.images.formats.file_renaming
+hardware: null
+inputs:
+- description: Filename pattern used to separate data
+  io_format:
+  - filePattern
+  io_type: string
+  name: filePattern
+  required: true
+- description: Input image collection to be processed by this plugin
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+- description: Desired filename pattern used to rename and separate data
+  io_format:
+  - outFilePattern
+  io_type: string
+  name: outFilePattern
+  required: true
+- description: Get directory name incorporated in renamed files
+  io_format:
+  - mapDirectory
+  io_type: string
+  name: mapDirectory
+  required: false
+name: polusai/FileRenaming
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/PolusAI/polus-plugins
+specVersion: 1.0.0
+title: File Renaming
+ui:
+- condition: null
+  customType: null
+  default: null
+  description: Filename pattern used to separate data
+  key: inputs.filePattern
+  regex: null
+  title: Filename pattern
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  description: Input image collection to be processed by this plugin
+  ext: null
+  key: inputs.inpDir
+  title: Input collection
+  ui_type: path
+- condition: null
+  customType: null
+  default: null
+  description: Desired filename pattern used to rename and separate data
+  key: inputs.outFilePattern
+  regex: null
+  title: Output filename pattern
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  description: Get directory name incorporated in renamed files
+  fields:
+  - raw
+  - map
+  - default
+  key: inputs.mapDirectory
+  optional: null
+  title: mapDirectory
+  ui_type: select
+version: 0.2.4-dev0

--- a/formats/label-to-vector-tool/ict.yaml
+++ b/formats/label-to-vector-tool/ict.yaml
@@ -1,0 +1,52 @@
+author:
+- Najib Ishaq
+- Nick Schaub
+citation: null
+contact: najib.ishaq@nih.gov
+container: polusai/label-to-vector-tool:0.7.1-dev0
+description: Convert labelled masks to flow-field vectors.
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Input image collection to be processed by this plugin
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+- description: Image-name pattern to use when selecting images for processing.
+  io_format:
+  - filePattern
+  io_type: string
+  name: filePattern
+  required: false
+name: polusai/LabeltoVector
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/PolusAI/polus-plugins/tree/dev/formats/polus-vector-converter-plugins
+specVersion: 1.0.0
+title: Label to Vector
+ui:
+- condition: null
+  customType: null
+  description: Input image collection to be processed by this plugin
+  ext: null
+  key: inputs.inpDir
+  title: Input collection
+  ui_type: path
+- condition: null
+  customType: null
+  default: null
+  description: Image-name pattern to use when selecting images for processing.
+  key: inputs.filePattern
+  regex: null
+  title: File Pattern
+  toolbar: null
+  ui_type: text
+version: 0.7.1-dev0

--- a/formats/ome-converter-tool/ict.yaml
+++ b/formats/ome-converter-tool/ict.yaml
@@ -1,0 +1,69 @@
+author:
+- Nick Schaub
+- Hamdah Shafqat
+citation: null
+contact: nick.schaub@nih.gov
+container: polusai/ome-converter-tool:0.3.2-dev0
+description: Convert Bioformats supported format to OME Zarr or OME TIF
+documentation: null
+entrypoint: python3 -m polus.images.formats.ome_converter
+hardware: null
+inputs:
+- description: Input generic data collection to be processed by this plugin
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+- description: A filepattern, used to select data to be converted
+  io_format:
+  - filePattern
+  io_type: string
+  name: filePattern
+  required: true
+- description: Type of data conversion
+  io_format:
+  - fileExtension
+  io_type: string
+  name: fileExtension
+  required: true
+name: polusai/OMEConverter
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/PolusAI/polus-plugins
+specVersion: 1.0.0
+title: OME Converter
+ui:
+- condition: null
+  customType: null
+  description: Input generic data collection to be processed by this plugin
+  ext: null
+  key: inputs.inpDir
+  title: Input generic collection
+  ui_type: path
+- condition: null
+  customType: null
+  default: null
+  description: A filepattern, used to select data for conversion
+  key: inputs.filePattern
+  regex: null
+  title: Filepattern
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  description: Type of data conversion
+  fields:
+  - .ome.tif
+  - .ome.zarr
+  - default
+  key: inputs.fileExtension
+  optional: null
+  title: fileExtension
+  ui_type: select
+version: 0.3.2-dev0

--- a/formats/polus-czi-extract-plugin/ict.yaml
+++ b/formats/polus-czi-extract-plugin/ict.yaml
@@ -1,0 +1,36 @@
+author:
+- Nick Schaub
+citation: null
+contact: nick.schaub@nih.gov
+container: polusai/czi-extract-plugin:1.1.1
+description: Extracts individual fields of view from a CZI file. Saves as OME TIFF.
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Input collection
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+name: polusai/ExtractTIFFsFromCZI
+outputs:
+- description: Output data for the plugin
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/polusai/image-tools
+specVersion: 1.0.0
+title: Extract TIFFs From CZI
+ui:
+- condition: null
+  customType: null
+  description: Collection name...
+  ext: null
+  key: inputs.inpDir
+  title: 'Input collection: '
+  ui_type: path
+version: 1.1.1

--- a/formats/polus-fcs-to-csv-converter-plugin/ict.yaml
+++ b/formats/polus-fcs-to-csv-converter-plugin/ict.yaml
@@ -1,0 +1,36 @@
+author:
+- Jayapriya Nagarajan
+citation: null
+contact: jayapriya.nagarajan@nih.gov
+container: polusai/fcs-to-csv-converter-plugin:0.2.5
+description: Converts fcs file to csv file
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Fcs file collection
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+name: polusai/FcstoCsvfileconverter
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: Fcs to Csv file converter
+ui:
+- condition: null
+  customType: null
+  description: Fcs file collection
+  ext: null
+  key: inputs.inpDir
+  title: Fcs file collection
+  ui_type: path
+version: 0.2.5

--- a/formats/polus-imaris-parser-plugin/ict.yaml
+++ b/formats/polus-imaris-parser-plugin/ict.yaml
@@ -1,0 +1,43 @@
+author:
+- Melanie Parham
+citation: null
+contact: melanie.parham@nih.gov
+container: polusai/imaris-parser-plugin:0.3.3
+description: Parses metadata of Imaris files and outputs features in organized csv
+  format.
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Input image collection to be processed by this plugin
+  io_format:
+  - inpdir
+  io_type: path
+  name: inpdir
+  required: true
+name: polusai/ImarisParser
+outputs:
+- description: Metadata directory that stores overall data
+  io_format:
+  - metaoutdir
+  io_type: path
+  name: metaoutdir
+  required: true
+- description: Output collection
+  io_format:
+  - outdir
+  io_type: path
+  name: outdir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: Imaris Parser
+ui:
+- condition: null
+  customType: null
+  description: Input image collection to be processed by this plugin
+  ext: null
+  key: inputs.inpdir
+  title: Input collection
+  ui_type: path
+version: 0.3.3

--- a/formats/polus-multichannel-tiff-plugin/ict.yaml
+++ b/formats/polus-multichannel-tiff-plugin/ict.yaml
@@ -1,0 +1,66 @@
+author:
+- Nick Schaub
+citation: null
+contact: nick.schaub@nih.gov
+container: polusai/multichannel-tiff-plugin:0.2.3
+description: Create multichannel, ome-tif from an image collection.
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Input image collection to be processed by this plugin
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+- description: Filename pattern used to separate data
+  io_format:
+  - filePattern
+  io_type: string
+  name: filePattern
+  required: true
+- description: Channel order
+  io_format:
+  - channelOrder
+  io_type: array
+  name: channelOrder
+  required: true
+name: polusai/MultichannelTiff
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: Multichannel Tiff
+ui:
+- condition: null
+  customType: null
+  description: Input image collection to be processed by this plugin
+  ext: null
+  key: inputs.inpDir
+  title: Input collection
+  ui_type: path
+- condition: null
+  customType: null
+  default: null
+  description: Filename pattern used to separate data
+  key: inputs.filePattern
+  regex: null
+  title: Filename pattern
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  default: null
+  description: Order to place images in
+  key: inputs.channelOrder
+  regex: null
+  title: Channel Order
+  toolbar: null
+  ui_type: text
+version: 0.2.3

--- a/formats/polus-tiledtiff-converter-plugin/ict.yaml
+++ b/formats/polus-tiledtiff-converter-plugin/ict.yaml
@@ -1,0 +1,36 @@
+author:
+- Nick Schaub
+citation: null
+contact: nick.schaub@nih.gov
+container: polusai/tiledtiff-converter-plugin:1.1.2
+description: Convert any Bioformats image file type to tiled tiff.
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Image inputs for the plugin.
+  io_format:
+  - input
+  io_type: path
+  name: input
+  required: true
+name: polusai/OMETiledTiffConverter
+outputs:
+- description: Output data for the plugin
+  io_format:
+  - output
+  io_type: path
+  name: output
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: OME Tiled Tiff Converter
+ui:
+- condition: null
+  customType: null
+  description: Pick a collection...
+  ext: null
+  key: inputs.input
+  title: 'Image Collection: '
+  ui_type: path
+version: 1.1.2

--- a/formats/tabular-converter-tool/ict.yaml
+++ b/formats/tabular-converter-tool/ict.yaml
@@ -1,0 +1,75 @@
+author:
+- Kelechi Nina
+- Hamdah Shafqat
+citation: null
+contact: nina.mezu@nih.gov
+container: polusai/tabular-converter-tool:0.1.2-dev0
+description: WIPP plugin allows tabular data conversion arrow file format and vice
+  versa.
+documentation: null
+entrypoint: python3 -m polus.images.formats.tabular_converter
+hardware: null
+inputs:
+- description: Input data collection to be processed by this plugin
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+- description: Pattern to parse input files
+  io_format:
+  - filePattern
+  io_type: string
+  name: filePattern
+  required: false
+- description: File format of an output file
+  io_format:
+  - fileExtension
+  io_type: string
+  name: fileExtension
+  required: true
+name: polusai/TabularConverter
+outputs:
+- description: Output directory
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/PolusAI/polus-plugins
+specVersion: 1.0.0
+title: Tabular Converter
+ui:
+- condition: null
+  customType: null
+  description: Input data collection to be processed by this plugin
+  ext: null
+  key: inputs.inpDir
+  title: Input collection
+  ui_type: path
+- condition: null
+  customType: null
+  default: null
+  description: Pattern to parse input files
+  key: inputs.filePattern
+  regex: null
+  title: FilePattern
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  description: Desired file format of an ouput file
+  fields:
+  - .csv
+  - .fits
+  - .fcs
+  - .feather
+  - .parquet
+  - .hdf5
+  - .arrow
+  - default
+  key: inputs.fileExtension
+  optional: null
+  title: FileExtension
+  ui_type: select
+version: 0.1.2-dev0

--- a/formats/tabular-to-arrow-tool/ict.yaml
+++ b/formats/tabular-to-arrow-tool/ict.yaml
@@ -1,0 +1,57 @@
+author:
+- Kelechi Nina
+- Hamdah Shafqat
+citation: null
+contact: nina.mezu@nih.gov
+container: polusai/tabular-to-arrow-tool:0.2.3-dev0
+description: WIPP plugin to converts Tabular Data to Arrow file format.
+documentation: null
+entrypoint: python3 -m polus.images.formats.tabular_to_arrow
+hardware: null
+inputs:
+- description: Filename pattern used to separate data
+  io_format:
+  - filePattern
+  io_type: string
+  name: filePattern
+  required: true
+- description: Input image collection to be processed by this plugin
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+name: polusai/TabulartoArrow
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/PolusAI/polus-plugins
+specVersion: 1.0.0
+title: Tabular to Arrow
+ui:
+- condition: null
+  customType: null
+  description: Filename pattern used to separate data
+  fields:
+  - .fcs
+  - .csv
+  - .feather
+  - .parquet
+  - .hdf5
+  - .fits
+  key: inputs.filePattern
+  optional: null
+  title: Filename pattern
+  ui_type: select
+- condition: null
+  customType: null
+  description: Input generic data collection to be processed by this plugin
+  ext: null
+  key: inputs.inpDir
+  title: Input collection
+  ui_type: path
+version: 0.2.3-dev0

--- a/formats/vector-to-label-tool/ict.yaml
+++ b/formats/vector-to-label-tool/ict.yaml
@@ -1,0 +1,52 @@
+author:
+- Nick Schaub
+- Najib Ishaq
+citation: null
+contact: nick.schaub@nih.gov
+container: polusai/vector-to-label-tool:0.7.1-dev0
+description: Create labelled masks from flow-field vectors.
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Input image collection to be processed by this plugin
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+- description: Image-name pattern to use when selecting images for processing.
+  io_format:
+  - filePattern
+  io_type: string
+  name: filePattern
+  required: false
+name: polusai/VectortoLabel
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/PolusAI/polus-plugins/tree/dev/formats/polus-vector-converter-plugin
+specVersion: 1.0.0
+title: Vector to Label
+ui:
+- condition: null
+  customType: null
+  description: Input image collection to be processed by this plugin.
+  ext: null
+  key: inputs.inpDir
+  title: Input collection
+  ui_type: path
+- condition: null
+  customType: null
+  default: null
+  description: Image-name pattern to use when selecting images for processing.
+  key: inputs.filePattern
+  regex: null
+  title: File Pattern
+  toolbar: null
+  ui_type: text
+version: 0.7.1-dev0

--- a/regression/basic-flatfield-estimation-tool/ict.yaml
+++ b/regression/basic-flatfield-estimation-tool/ict.yaml
@@ -1,0 +1,81 @@
+author:
+- Nick Schaub
+- Najib Ishaq
+citation: null
+contact: nick.schaub@nih.gov
+container: polusai/basic-flatfield-estimation-tool:2.1.2-dev0
+description: Generates images used for flatfield correction using the BaSiC algorithm.
+documentation: null
+entrypoint: python3 -m polus.images.regression.basic_flatfield_estimation
+hardware: null
+inputs:
+- description: Input image collection.
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+- description: Filename pattern used to separate images by channel, timepoint, and
+    replicate.
+  io_format:
+  - filePattern
+  io_type: string
+  name: filePattern
+  required: true
+- description: Group images together for flatfield by variable.
+  io_format:
+  - groupBy
+  io_type: string
+  name: groupBy
+  required: false
+- description: Calculate darkfield image.
+  io_format:
+  - getDarkfield
+  io_type: boolean
+  name: getDarkfield
+  required: true
+name: polusai/FlatfieldEstimationusingBaSiCalgorithm.
+outputs:
+- description: Output data for the plugin
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/polusai/polus-plugins
+specVersion: 1.0.0
+title: Flatfield Estimation using BaSiC algorithm.
+ui:
+- condition: null
+  customType: null
+  description: Image collection...
+  ext: null
+  key: inputs.inpDir
+  title: 'Input image collection: '
+  ui_type: path
+- condition: null
+  customType: null
+  default: null
+  description: Use a filename pattern to calculate flatfield information by subsets
+  key: inputs.filePattern
+  regex: null
+  title: 'Filename pattern: '
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  default: null
+  description: Group data together with varying variable values.
+  key: inputs.groupBy
+  regex: null
+  title: 'Grouping Variables: '
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  default: null
+  description: If selected, will generate a darkfield image
+  key: inputs.getDarkfield
+  title: 'Calculate darkfield: '
+  ui_type: checkbox
+version: 2.1.2-dev0

--- a/regression/basic-flatfield-estimation-tool/plugin.json
+++ b/regression/basic-flatfield-estimation-tool/plugin.json
@@ -64,7 +64,7 @@
       "description": "Group data together with varying variable values."
     },
     {
-      "key": "inputs.darkfield",
+      "key": "inputs.getDarkfield",
       "title": "Calculate darkfield: ",
       "description": "If selected, will generate a darkfield image"
     }

--- a/regression/theia-bleedthrough-estimation-tool/ict.yaml
+++ b/regression/theia-bleedthrough-estimation-tool/ict.yaml
@@ -1,0 +1,130 @@
+author:
+- Najib Ishaq
+- Nick Schaub
+citation: null
+contact: najib.ishaq@nih.gov
+container: polusai/theia-bleedthrough-estimation-tool:0.5.2-dev0
+description: Performs bleed-through estimation for images.
+documentation: null
+entrypoint: python3 -m polus.images.regression.theia_bleedthrough_estimation
+hardware: null
+inputs:
+- description: Input image collection.
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+- description: File pattern to subset images.
+  io_format:
+  - filePattern
+  io_type: string
+  name: filePattern
+  required: false
+- description: Variables to group together.
+  io_format:
+  - groupBy
+  io_type: string
+  name: groupBy
+  required: false
+- description: Channel ordering by wavelength scale.
+  io_format:
+  - channelOrdering
+  io_type: string
+  name: channelOrdering
+  required: false
+- description: Method to use for selecting tiles.
+  io_format:
+  - selectionCriterion
+  io_type: string
+  name: selectionCriterion
+  required: false
+- description: Number of adjacent channels to consider.
+  io_format:
+  - channelOverlap
+  io_type: number
+  name: channelOverlap
+  required: false
+- description: Size of convolution kernels to learn.
+  io_format:
+  - kernelSize
+  io_type: number
+  name: kernelSize
+  required: false
+name: polusai/BleedThroughEstimation
+outputs:
+- description: Location for writing bleed-through components.
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/polusai/polus-plugins/tree/dev/regression
+specVersion: 1.0.0
+title: BleedThroughEstimation
+ui:
+- condition: null
+  customType: null
+  description: Image collection...
+  ext: null
+  key: inputs.inpDir
+  title: 'Input image collection: '
+  ui_type: path
+- condition: null
+  customType: null
+  default: null
+  description: File pattern to subset images.
+  key: inputs.filePattern
+  regex: null
+  title: 'Filename pattern: '
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  default: null
+  description: Variables to group together.
+  key: inputs.groupBy
+  regex: null
+  title: 'Grouping Variables: '
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  default: null
+  description: Channel ordering by wavelength scale.
+  key: inputs.channelOrdering
+  regex: null
+  title: 'Channel Ordering: '
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  description: Method to use for selecting tiles.
+  fields:
+  - MeanIntensity
+  - Entropy
+  - MedianIntensity
+  - IntensityRange
+  key: inputs.selectionCriterion
+  optional: null
+  title: 'Selection Criterion: '
+  ui_type: select
+- condition: null
+  customType: null
+  default: 1
+  description: Number of adjacent channels to consider.
+  integer: null
+  key: inputs.channelOverlap
+  number_range: null
+  title: 'Channel Overlap: '
+  ui_type: number
+- condition: null
+  customType: null
+  default: 3
+  description: Size of convolutional kernels to learn.
+  integer: null
+  key: inputs.kernelSize
+  number_range: null
+  title: 'Kernel Size: '
+  ui_type: number
+version: 0.5.2-dev0

--- a/segmentation/cell-border-segmentation-tool/ict.yaml
+++ b/segmentation/cell-border-segmentation-tool/ict.yaml
@@ -1,0 +1,65 @@
+author:
+- Nick Schaub
+- Hamdah Shafqat
+citation: null
+contact: nick.schaub@nih.gov
+container: polusai/cell-border-segmentation-tool:0.2.4-dev0
+description: Segment cell borders of epithelial cells.
+documentation: null
+entrypoint: python3 -m polus.images.segmentation.cell_border_segmentation
+hardware: null
+inputs:
+- description: Input image collection to be processed by this plugin.
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+- description: Filename pattern used to separate data.
+  io_format:
+  - filePattern
+  io_type: string
+  name: filePattern
+  required: false
+- description: Generate an output preview.
+  io_format:
+  - preview
+  io_type: boolean
+  name: preview
+  required: false
+name: polusai/CellBorderSegmentation
+outputs:
+- description: Output collection.
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/polusai/polus-plugins
+specVersion: 1.0.0
+title: Cell Border Segmentation
+ui:
+- condition: null
+  customType: null
+  description: Input image collection to be processed by this plugin.
+  ext: null
+  key: inputs.inpDir
+  title: Input collection
+  ui_type: path
+- condition: null
+  customType: null
+  default: null
+  description: Filename pattern used to separate data.
+  key: inputs.filePattern
+  regex: null
+  title: Filename pattern
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  default: null
+  description: Generate an output preview.
+  key: inputs.preview
+  title: Preview example output of this plugin
+  ui_type: checkbox
+version: 0.2.4-dev0

--- a/segmentation/cell-border-segmentation-tool/plugin.json
+++ b/segmentation/cell-border-segmentation-tool/plugin.json
@@ -14,50 +14,57 @@
     "-m",
     "polus.images.segmentation.cell_border_segmentation"
   ],
-  "inputs": {
-    "inpDir": {
+  "inputs": [
+    {
+      "name": "inpDir",
       "type": "collection",
       "title": "Input collection",
       "description": "Input image collection to be processed by this plugin.",
       "required": "True"
     },
-    "filePattern": {
+    {
+      "name": "filePattern",
       "type": "string",
       "title": "Filename pattern",
       "description": "Filename pattern used to separate data.",
       "required": "False"
     },
-    "preview": {
+    {
+      "name": "preview",
       "type": "boolean",
       "title": "Preview",
       "description": "Generate an output preview.",
       "required": "False"
     }
-  },
-  "outputs": {
-    "outDir": {
+  ],
+  "outputs": [
+    {
+      "name": "outDir",
       "type": "collection",
       "description": "Output collection."
     }
-  },
-  "ui": {
-    "inpDir": {
+  ],
+  "ui": [
+    {
+      "key": "inputs.inpDir",
       "type": "collection",
       "title": "Input collection",
       "description": "Input image collection to be processed by this plugin.",
       "required": "True"
     },
-    "filePattern": {
+    {
+      "key": "inputs.filePattern",
       "type": "string",
       "title": "Filename pattern",
       "description": "Filename pattern used to separate data.",
       "required": "False"
     },
-    "preview": {
+    {
+      "key": "inputs.preview",
       "type": "boolean",
       "title": "Preview example output of this plugin",
       "description": "Generate an output preview.",
       "required": "False"
     }
-  }
+  ]
 }

--- a/segmentation/mesmer-inference-tool/ict.yaml
+++ b/segmentation/mesmer-inference-tool/ict.yaml
@@ -1,0 +1,131 @@
+author:
+- Vishakha Goyal
+- Hamdah Shafqat
+citation: null
+contact: vishakha.goyal@nih.gov
+container: polusai/mesmer-inference-tool:0.0.9-dev0
+description: WIPP plugin to run inference using MESMER.
+documentation: null
+entrypoint: python3 -m polus.images.segmentation.mesmer_inference
+hardware: null
+inputs:
+- description: Input image collection to be processed by this plugin.
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+- description: Tile size for images. Default is 256.
+  io_format:
+  - tilesize
+  io_type: number
+  name: tilesize
+  required: false
+- description: Model path
+  io_format:
+  - modelPath
+  io_type: path
+  name: modelPath
+  required: false
+- description: Filename pattern to filter test data.
+  io_format:
+  - filePatternTest
+  io_type: string
+  name: filePatternTest
+  required: true
+- description: Filename pattern to filter nuclear data for whole cell segmentation.
+  io_format:
+  - filePatternWholeCell
+  io_type: string
+  name: filePatternWholeCell
+  required: false
+- description: Format to save predictions
+  io_format:
+  - fileExtension
+  io_type: string
+  name: fileExtension
+  required: true
+- description: Select which model to use. Default is mesmer.
+  io_format:
+  - model
+  io_type: string
+  name: model
+  required: true
+name: polusai/MesmerInference
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/polusai/polus-plugins
+specVersion: 1.0.0
+title: Mesmer Inference
+ui:
+- condition: null
+  customType: null
+  description: Input intesity image collection to be processed by this plugin.
+  ext: null
+  key: inputs.inpDir
+  title: Test intensity images
+  ui_type: path
+- condition: null
+  customType: null
+  default: null
+  description: Tile size for input images.
+  integer: null
+  key: inputs.tilesize
+  number_range: null
+  title: Tile Size
+  ui_type: number
+- condition: null
+  customType: null
+  description: Path for model file.
+  ext: null
+  key: inputs.modelPath
+  title: Model Path
+  ui_type: path
+- condition: null
+  customType: null
+  default: null
+  description: Filename pattern to filter test data.
+  key: inputs.filePatternTest
+  regex: null
+  title: FilePattern Test
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  default: null
+  description: Filename pattern to filter nuclear data for whole cell segmentation.
+  key: inputs.filePatternWholeCell
+  regex: null
+  title: FilePattern Whole Cell
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  description: Format to save predictions
+  fields:
+  - .ome.tif
+  - .ome.zarr
+  - default
+  key: inputs.fileExtension
+  optional: null
+  title: fileExtension
+  ui_type: select
+- condition: null
+  customType: null
+  description: Choose the model
+  fields:
+  - mesmerNuclear
+  - mesmerWholeCell
+  - nuclear
+  - cytoplasm
+  - BYOM
+  key: inputs.model
+  optional: null
+  title: Model Name
+  ui_type: select
+version: 0.0.9-dev0

--- a/segmentation/mesmer-training-tool/ict.yaml
+++ b/segmentation/mesmer-training-tool/ict.yaml
@@ -1,0 +1,142 @@
+author:
+- Vishakha Goyal
+- Hamdah Shafqat
+citation: null
+contact: vishakha.goyal@nih.gov
+container: polusai/mesmer-training-tool:0.0.7-dev0
+description: WIPP plugin to train PanopticNet model.
+documentation: null
+entrypoint: python3 -m polus.images.segmentation.mesmer_training
+hardware: null
+inputs:
+- description: Input training image collection to be processed by this plugin
+  io_format:
+  - trainingImages
+  io_type: path
+  name: trainingImages
+  required: true
+- description: Input training label collection to be processed by this plugin
+  io_format:
+  - trainingLabels
+  io_type: path
+  name: trainingLabels
+  required: true
+- description: Input testing image collection to be processed by this plugin
+  io_format:
+  - testingImages
+  io_type: path
+  name: testingImages
+  required: true
+- description: Input testing label collection to be processed by this plugin
+  io_format:
+  - testingLabels
+  io_type: path
+  name: testingLabels
+  required: true
+- description: Keras models
+  io_format:
+  - modelBackbone
+  io_type: string
+  name: modelBackbone
+  required: true
+- description: Pattern to parse file names.
+  io_format:
+  - filePattern
+  io_type: string
+  name: filePattern
+  required: false
+- description: tile size
+  io_format:
+  - tilesize
+  io_type: number
+  name: tilesize
+  required: false
+- description: Number of training iterations
+  io_format:
+  - iterations
+  io_type: number
+  name: iterations
+  required: false
+- description: batch size for training
+  io_format:
+  - batchSize
+  io_type: number
+  name: batchSize
+  required: false
+name: polusai/MESMERTraining
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/polusai/polus-plugins
+specVersion: 1.0.0
+title: MESMER Training
+ui:
+- condition: null
+  customType: null
+  description: Input training image collection to be processed by this plugin
+  ext: null
+  key: inputs.trainingImages
+  title: trainingImages
+  ui_type: path
+- condition: null
+  customType: null
+  description: Input training label collection to be processed by this plugin
+  ext: null
+  key: inputs.trainingLabels
+  title: trainingLabels
+  ui_type: path
+- condition: null
+  customType: null
+  description: Input testing image collection to be processed by this plugin
+  ext: null
+  key: inputs.testingImages
+  title: testingImages
+  ui_type: path
+- condition: null
+  customType: null
+  description: Input testing label collection to be processed by this plugin
+  ext: null
+  key: inputs.testingLabels
+  title: testingLabels
+  ui_type: path
+- condition: null
+  customType: null
+  default: null
+  description: Pattern to parse file names.
+  key: inputs.filePattern
+  regex: null
+  title: FilePattern
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  default: null
+  description: tile size. Default is 256.
+  integer: null
+  key: inputs.tilesize
+  number_range: null
+  title: tile size
+  ui_type: number
+- condition: null
+  customType: null
+  default: null
+  description: Number of training iterations. Default is 10.
+  integer: null
+  key: inputs.iterations
+  number_range: null
+  title: training iterations
+  ui_type: number
+- condition: null
+  customType: null
+  default: null
+  description: batch size. Default is 1.
+  integer: null
+  key: inputs.batchSize
+  number_range: null
+  title: batch size
+  ui_type: number
+version: 0.0.7-dev0

--- a/segmentation/polus-aics-classic-seg-plugin/ict.yaml
+++ b/segmentation/polus-aics-classic-seg-plugin/ict.yaml
@@ -1,0 +1,49 @@
+author:
+- Gauhar Bains
+citation: null
+contact: gauhar.bains@labshare.org
+container: polusai/aics-classic-seg-plugin:0.1.11
+description: The plugin integrates the allen cell structure segmenter into WIPP
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Configuration file for the workflow
+  io_format:
+  - configFile
+  io_type: path
+  name: configFile
+  required: true
+- description: Input image collection to be processed by this plugin
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+name: polusai/AicsClassicSegmentation
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: Aics Classic Segmentation
+ui:
+- condition: null
+  customType: null
+  description: Configuration file for the workflow
+  ext: null
+  key: inputs.configFile
+  title: Config File
+  ui_type: path
+- condition: null
+  customType: null
+  description: Input image collection to be processed by this plugin
+  ext: null
+  key: inputs.inpDir
+  title: Input collection
+  ui_type: path
+version: 0.1.11

--- a/segmentation/polus-cell-nuclei-segmentation-plugin/ict.yaml
+++ b/segmentation/polus-cell-nuclei-segmentation-plugin/ict.yaml
@@ -1,0 +1,39 @@
+author:
+- Gauhar Bains
+- Konstantin Taletskiy
+- Nick Schaub
+citation: null
+contact: gauhar.bains@labshare.org
+container: polusai/cell-nuclei-segmentation-plugin:0.1.4
+description: ' Segments cell nuclei using U-Net in Tensorflow. Neural net architecture
+  and pretrained weights are taken from Data Science Bowl 2018 entry by Muhammad Asim'
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Input Image Collection for the plugin.
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+name: polusai/CellNucleiSegmentaionusingU-net
+outputs:
+- description: Output Image Collection for the plugin.
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: Cell Nuclei Segmentaion using U-net
+ui:
+- condition: null
+  customType: null
+  description: Pick a collection...
+  ext: null
+  key: inputs.inpDir
+  title: 'Image Collection: '
+  ui_type: path
+version: 0.1.4

--- a/segmentation/polus-imagej-threshold-apply-plugin/ict.yaml
+++ b/segmentation/polus-imagej-threshold-apply-plugin/ict.yaml
@@ -1,0 +1,68 @@
+author:
+- Nick Schaub
+- Anjali Taneja
+- Benjamin Houghton
+citation: null
+contact: nick.schaub@nih.gov
+container: polusai/imagej-threshold-apply-plugin:0.4.2
+description: This plugin applies a constant or manual threshold to an input collection.
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Op overloading method to perform
+  io_format:
+  - opName
+  io_type: string
+  name: opName
+  required: true
+- description: Collection to be processed by this plugin
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+- description: The threshold value to be applied to the input
+  io_format:
+  - threshold
+  io_type: number
+  name: threshold
+  required: true
+name: polusai/ImageJthresholdapply
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: ImageJ threshold apply
+ui:
+- condition: null
+  customType: null
+  description: Op overloading method to perform
+  fields:
+  - ApplyManualThreshold
+  key: inputs.opName
+  optional: null
+  title: opName
+  ui_type: select
+- condition: null
+  customType: null
+  description: Collection to be processed by this plugin
+  ext: null
+  key: inputs.inpDir
+  title: inpDir
+  ui_type: path
+- condition: null
+  customType: null
+  default: null
+  description: The threshold value to be applied to the input
+  integer: null
+  key: inputs.threshold
+  number_range: null
+  title: threshold
+  ui_type: number
+version: 0.4.2

--- a/segmentation/polus-imagej-threshold-huang-plugin/ict.yaml
+++ b/segmentation/polus-imagej-threshold-huang-plugin/ict.yaml
@@ -1,0 +1,53 @@
+author:
+- Nick Schaub
+- Anjali Taneja
+- Benjamin Houghton
+citation: null
+contact: nick.schaub@nih.gov
+container: polusai/imagej-threshold-huang-plugin:0.4.2
+description: This plugin implements Huang's threshold method by Huang Wang.
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Op overloading method to perform
+  io_format:
+  - opName
+  io_type: string
+  name: opName
+  required: true
+- description: The collection to be processed by this plugin
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+name: polusai/ImageJthresholdhuang
+outputs:
+- description: The output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: ImageJ threshold huang
+ui:
+- condition: null
+  customType: null
+  description: Op overloading method to perform
+  fields:
+  - ApplyThresholdMethod$Huang
+  key: inputs.opName
+  optional: null
+  title: opName
+  ui_type: select
+- condition: null
+  customType: null
+  description: The collection to be processed by this plugin
+  ext: null
+  key: inputs.inpDir
+  title: inpDir
+  ui_type: path
+version: 0.4.2

--- a/segmentation/polus-imagej-threshold-ij1-plugin/ict.yaml
+++ b/segmentation/polus-imagej-threshold-ij1-plugin/ict.yaml
@@ -1,0 +1,53 @@
+author:
+- Nick Schaub
+- Anjali Taneja
+- Benjamin Houghton
+citation: null
+contact: nick.schaub@nih.gov
+container: polusai/imagej-threshold-ij1-plugin:0.4.2
+description: This plugin implements the default thresholding method from ImageJ 1.x
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Op overloading method to perform
+  io_format:
+  - opName
+  io_type: string
+  name: opName
+  required: true
+- description: The collection to be processed by this plugin
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+name: polusai/ImageJthresholdij1
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: ImageJ threshold ij1
+ui:
+- condition: null
+  customType: null
+  description: Op overloading method to perform
+  fields:
+  - ApplyThresholdMethod$IJ1
+  key: inputs.opName
+  optional: null
+  title: opName
+  ui_type: select
+- condition: null
+  customType: null
+  description: The collection to be processed by this plugin
+  ext: null
+  key: inputs.inpDir
+  title: inpDir
+  ui_type: path
+version: 0.4.2

--- a/segmentation/polus-imagej-threshold-intermodes-plugin/ict.yaml
+++ b/segmentation/polus-imagej-threshold-intermodes-plugin/ict.yaml
@@ -1,0 +1,54 @@
+author:
+- Nick Schaub
+- Anjali Taneja
+- Benjamin Houghton
+citation: null
+contact: nick.schaub@nih.gov
+container: polusai/imagej-threshold-intermodes-plugin:0.4.2
+description: The plugin implements the Intermodes thresholding operation, where it
+  is assumed the input image has bimodal distribution of pixel values
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Op overloading method to perform
+  io_format:
+  - opName
+  io_type: string
+  name: opName
+  required: true
+- description: Collection to be processed by this plugin
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+name: polusai/ImageJthresholdintermodes
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: ImageJ threshold intermodes
+ui:
+- condition: null
+  customType: null
+  description: Op overloading method to perform
+  fields:
+  - ApplyThresholdMethod$Intermodes
+  key: inputs.opName
+  optional: null
+  title: opName
+  ui_type: select
+- condition: null
+  customType: null
+  description: Collection to be processed by this plugin
+  ext: null
+  key: inputs.inpDir
+  title: inpDir
+  ui_type: path
+version: 0.4.2

--- a/segmentation/polus-imagej-threshold-isodata-plugin/ict.yaml
+++ b/segmentation/polus-imagej-threshold-isodata-plugin/ict.yaml
@@ -1,0 +1,55 @@
+author:
+- Nick Schaub
+- Anjali Taneja
+- Benjamin Houghton
+citation: null
+contact: nick.schaub@nih.gov
+container: polusai/imagej-threshold-isodata-plugin:0.4.2
+description: "Iterative procedure based on the isodata algorithm of:  Picture Thresholding\
+  \ Using an Iterative Selection Method. (1978). IEEE Transactions on Systems, Man,\
+  \ and Cybernetics, 8(8), 630\u2013632. doi:10.1109/tsmc.1978.4310039"
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Op overloading method to perform
+  io_format:
+  - opName
+  io_type: string
+  name: opName
+  required: true
+- description: Collection to be processed by this plugin
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+name: polusai/ImageJthresholdisoData
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: ImageJ threshold isoData
+ui:
+- condition: null
+  customType: null
+  description: Op overloading method to perform
+  fields:
+  - ApplyThresholdMethod$IsoData
+  key: inputs.opName
+  optional: null
+  title: opName
+  ui_type: select
+- condition: null
+  customType: null
+  description: Collection to be processed by this plugin
+  ext: null
+  key: inputs.inpDir
+  title: inpDir
+  ui_type: path
+version: 0.4.2

--- a/segmentation/polus-imagej-threshold-li-plugin/ict.yaml
+++ b/segmentation/polus-imagej-threshold-li-plugin/ict.yaml
@@ -1,0 +1,54 @@
+author:
+- Nick Schaub
+- Anjali Taneja
+- Benjamin Houghton
+citation: null
+contact: nick.schaub@nih.gov
+container: polusai/imagej-threshold-li-plugin:0.4.2
+description: "Implements Li\u2019s Minimum Cross Entropy thresholding method based\
+  \ on the iterative version of the algorithm."
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Operation to perform
+  io_format:
+  - opName
+  io_type: string
+  name: opName
+  required: true
+- description: Collection to be processed by this plugin
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+name: polusai/ImageJthresholdli
+outputs:
+- description: Output colleciton
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: ImageJ threshold li
+ui:
+- condition: null
+  customType: null
+  description: Operation to perform
+  fields:
+  - ApplyThresholdMethod$Li
+  key: inputs.opName
+  optional: null
+  title: opName
+  ui_type: select
+- condition: null
+  customType: null
+  description: Collection to be processed by this plugin
+  ext: null
+  key: inputs.inpDir
+  title: inpDir
+  ui_type: path
+version: 0.4.2

--- a/segmentation/polus-imagej-threshold-maxentropy-plugin/ict.yaml
+++ b/segmentation/polus-imagej-threshold-maxentropy-plugin/ict.yaml
@@ -1,0 +1,53 @@
+author:
+- Nick Schaub
+- Anjali Taneja
+- Benjamin Houghton
+citation: null
+contact: nick.schaub@nih.gov
+container: polusai/imagej-threshold-maxentropy-plugin:0.4.2
+description: Implements Kapur-Sahoo-Wong (Maximum Entropy) thresholding method.
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Operation to perform
+  io_format:
+  - opName
+  io_type: string
+  name: opName
+  required: true
+- description: The collection to be processed by this plugin
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+name: polusai/ImageJthresholdmaxEntropy
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: ImageJ threshold maxEntropy
+ui:
+- condition: null
+  customType: null
+  description: Operation to perform
+  fields:
+  - ApplyThresholdMethod$MaxEntropy
+  key: inputs.opName
+  optional: null
+  title: opName
+  ui_type: select
+- condition: null
+  customType: null
+  description: The collection to be processed by this plugin
+  ext: null
+  key: inputs.inpDir
+  title: inpDir
+  ui_type: path
+version: 0.4.2

--- a/segmentation/polus-imagej-threshold-maxlikelihood-plugin/ict.yaml
+++ b/segmentation/polus-imagej-threshold-maxlikelihood-plugin/ict.yaml
@@ -1,0 +1,54 @@
+author:
+- Nick Schaub
+- Anjali Taneja
+- Benjamin Houghton
+citation: null
+contact: nick.schaub@nih.gov
+container: polusai/imagej-threshold-maxlikelihood-plugin:0.4.2
+description: Implements a maximum likelihood threshold method by Dempster, Laird,
+  Rubin and Glasbey.
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Operation to perform
+  io_format:
+  - opName
+  io_type: string
+  name: opName
+  required: true
+- description: Collection to be processed by this plugin
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+name: polusai/ImageJthresholdmaxLikelihood
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: ImageJ threshold maxLikelihood
+ui:
+- condition: null
+  customType: null
+  description: Operation to perform
+  fields:
+  - ApplyThresholdMethod$MaxLikelihood
+  key: inputs.opName
+  optional: null
+  title: opName
+  ui_type: select
+- condition: null
+  customType: null
+  description: Collection to be processed by this plugin
+  ext: null
+  key: inputs.inpDir
+  title: inpDir
+  ui_type: path
+version: 0.4.2

--- a/segmentation/polus-imagej-threshold-mean-plugin/ict.yaml
+++ b/segmentation/polus-imagej-threshold-mean-plugin/ict.yaml
@@ -1,0 +1,54 @@
+author:
+- Nick Schaub
+- Anjali Taneja
+- Benjamin Houghton
+citation: null
+contact: nick.schaub@nih.gov
+container: polusai/imagej-threshold-mean-plugin:0.4.2
+description: Uses the mean of grey levels as the threshold. It is used by some other
+  methods as a first guess threshold.
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Operation to perform
+  io_format:
+  - opName
+  io_type: string
+  name: opName
+  required: true
+- description: Collection to be processed by this plugin
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+name: polusai/ImageJthresholdmean
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: ImageJ threshold mean
+ui:
+- condition: null
+  customType: null
+  description: Operation to perform
+  fields:
+  - ApplyThresholdMethod$Mean
+  key: inputs.opName
+  optional: null
+  title: opName
+  ui_type: select
+- condition: null
+  customType: null
+  description: Collection to be processed by this plugin
+  ext: null
+  key: inputs.inpDir
+  title: inpDir
+  ui_type: path
+version: 0.4.2

--- a/segmentation/polus-imagej-threshold-minerror-plugin/ict.yaml
+++ b/segmentation/polus-imagej-threshold-minerror-plugin/ict.yaml
@@ -1,0 +1,54 @@
+author:
+- Nick Schaub
+- Anjali Taneja
+- Benjamin Houghton
+citation: null
+contact: nick.schaub@nih.gov
+container: polusai/imagej-threshold-minerror-plugin:0.4.2
+description: An iterative implementation of Kittler and Illingworth's Minimum Error
+  thresholding.
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Operation to perform
+  io_format:
+  - opName
+  io_type: string
+  name: opName
+  required: true
+- description: Collection to be processed by this plugin
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+name: polusai/ImageJthresholdminError
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: ImageJ threshold minError
+ui:
+- condition: null
+  customType: null
+  description: Operation to perform
+  fields:
+  - ApplyThresholdMethod$MinError
+  key: inputs.opName
+  optional: null
+  title: opName
+  ui_type: select
+- condition: null
+  customType: null
+  description: Collection to be processed by this plugin
+  ext: null
+  key: inputs.inpDir
+  title: inpDir
+  ui_type: path
+version: 0.4.2

--- a/segmentation/polus-imagej-threshold-minimum-plugin/ict.yaml
+++ b/segmentation/polus-imagej-threshold-minimum-plugin/ict.yaml
@@ -1,0 +1,55 @@
+author:
+- Nick Schaub
+- Anjali Taneja
+- Benjamin Houghton
+citation: null
+contact: nick.schaub@nih.gov
+container: polusai/imagej-threshold-minimum-plugin:0.4.2
+description: Similarly to the Intermodes method, this assumes a bimodal histogram.
+  The histogram is iteratively smoothed using a running average of size 3, until there
+  are only two local maxima.
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Operation to perform
+  io_format:
+  - opName
+  io_type: string
+  name: opName
+  required: true
+- description: Collection to be processed by this plugin
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+name: polusai/ImageJthresholdminimum
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: ImageJ threshold minimum
+ui:
+- condition: null
+  customType: null
+  description: Operation to perform
+  fields:
+  - ApplyThresholdMethod$Minimum
+  key: inputs.opName
+  optional: null
+  title: opName
+  ui_type: select
+- condition: null
+  customType: null
+  description: Collection to be processed by this plugin
+  ext: null
+  key: inputs.inpDir
+  title: inpDir
+  ui_type: path
+version: 0.4.2

--- a/segmentation/polus-imagej-threshold-moments-plugin/ict.yaml
+++ b/segmentation/polus-imagej-threshold-moments-plugin/ict.yaml
@@ -1,0 +1,54 @@
+author:
+- Nick Schaub
+- Anjali Taneja
+- Benjamin Houghton
+citation: null
+contact: nick.schaub@nih.gov
+container: polusai/imagej-threshold-moments-plugin:0.4.2
+description: Tsai's method attempts to preserve the moments of the original image
+  in the thresholded result.
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Op overloading method to perform
+  io_format:
+  - opName
+  io_type: string
+  name: opName
+  required: true
+- description: Collection to be processed by this plugin
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+name: polusai/ImageJthresholdmoments
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: ImageJ threshold moments
+ui:
+- condition: null
+  customType: null
+  description: Op overloading method to perform
+  fields:
+  - ApplyThresholdMethod$Moments
+  key: inputs.opName
+  optional: null
+  title: opName
+  ui_type: select
+- condition: null
+  customType: null
+  description: Collection to be processed by this plugin
+  ext: null
+  key: inputs.inpDir
+  title: inpDir
+  ui_type: path
+version: 0.4.2

--- a/segmentation/polus-imagej-threshold-otsu-plugin/ict.yaml
+++ b/segmentation/polus-imagej-threshold-otsu-plugin/ict.yaml
@@ -1,0 +1,55 @@
+author:
+- Nick Schaub
+- Anjali Taneja
+- Benjamin Houghton
+citation: null
+contact: nick.schaub@nih.gov
+container: polusai/imagej-threshold-otsu-plugin:0.4.2
+description: Otsu's threshold clustering algorithm searches for the threshold that
+  minimizes the intra-class variance, defined as a weighted sum of variances of the
+  two classes.
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Op overloading method to perform
+  io_format:
+  - opName
+  io_type: string
+  name: opName
+  required: true
+- description: Collection to be processed by this plugin
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+name: polusai/ImageJthresholdotsu
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: ImageJ threshold otsu
+ui:
+- condition: null
+  customType: null
+  description: Op overloading method to perform
+  fields:
+  - ApplyThresholdMethod$Otsu
+  key: inputs.opName
+  optional: null
+  title: opName
+  ui_type: select
+- condition: null
+  customType: null
+  description: Collection to be processed by this plugin
+  ext: null
+  key: inputs.inpDir
+  title: inpDir
+  ui_type: path
+version: 0.4.2

--- a/segmentation/polus-imagej-threshold-percentile-plugin/ict.yaml
+++ b/segmentation/polus-imagej-threshold-percentile-plugin/ict.yaml
@@ -1,0 +1,53 @@
+author:
+- Nick Schaub
+- Anjali Taneja
+- Benjamin Houghton
+citation: null
+contact: nick.schaub@nih.gov
+container: polusai/imagej-threshold-percentile-plugin:0.4.2
+description: This plugin assumes the fraction of foreground pixels to be 0.5.
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Op overloading method to perform
+  io_format:
+  - opName
+  io_type: string
+  name: opName
+  required: true
+- description: Collection to be processed by this plugin
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+name: polusai/ImageJthresholdpercentile
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: ImageJ threshold percentile
+ui:
+- condition: null
+  customType: null
+  description: Op overloading method to perform
+  fields:
+  - ApplyThresholdMethod$Percentile
+  key: inputs.opName
+  optional: null
+  title: opName
+  ui_type: select
+- condition: null
+  customType: null
+  description: Collection to be processed by this plugin
+  ext: null
+  key: inputs.inpDir
+  title: inpDir
+  ui_type: path
+version: 0.4.2

--- a/segmentation/polus-imagej-threshold-renyientropy-plugin/ict.yaml
+++ b/segmentation/polus-imagej-threshold-renyientropy-plugin/ict.yaml
@@ -1,0 +1,53 @@
+author:
+- Nick Schaub
+- Anjali Taneja
+- Benjamin Houghton
+citation: null
+contact: nick.schaub@nih.gov
+container: polusai/imagej-threshold-renyientropy-plugin:0.4.2
+description: Uses Renyi entropy method by Kapur, Sahoo, to threshold input collection
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Operation to perform
+  io_format:
+  - opName
+  io_type: string
+  name: opName
+  required: true
+- description: Collection to be processed by this plugin
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: false
+name: polusai/ImageJthresholdrenyiEntropy
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: ImageJ threshold renyiEntropy
+ui:
+- condition: null
+  customType: null
+  description: Operation to perform
+  fields:
+  - ApplyThresholdMethod$RenyiEntropy
+  key: inputs.opName
+  optional: null
+  title: opName
+  ui_type: select
+- condition: null
+  customType: null
+  description: Collection to be processed by this plugin
+  ext: null
+  key: inputs.inpDir
+  title: inpDir
+  ui_type: path
+version: 0.4.2

--- a/segmentation/polus-imagej-threshold-rosin-plugin/ict.yaml
+++ b/segmentation/polus-imagej-threshold-rosin-plugin/ict.yaml
@@ -1,0 +1,53 @@
+author:
+- Nick Schaub
+- Anjali Taneja
+- Benjamin Houghton
+citation: null
+contact: nick.schaub@nih.gov
+container: polusai/imagej-threshold-rosin-plugin:0.4.2
+description: Implements Rosin's thresholding method for unimodal distributions.
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Operation to perform
+  io_format:
+  - opName
+  io_type: string
+  name: opName
+  required: true
+- description: Collection to be processed by this plugin
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+name: polusai/ImageJthresholdrosin
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: ImageJ threshold rosin
+ui:
+- condition: null
+  customType: null
+  description: Operation to perform
+  fields:
+  - ApplyThresholdMethod$Rosin
+  key: inputs.opName
+  optional: null
+  title: opName
+  ui_type: select
+- condition: null
+  customType: null
+  description: Collection to be processed by this plugin
+  ext: null
+  key: inputs.inpDir
+  title: inpDir
+  ui_type: path
+version: 0.4.2

--- a/segmentation/polus-imagej-threshold-shanbhag-plugin/ict.yaml
+++ b/segmentation/polus-imagej-threshold-shanbhag-plugin/ict.yaml
@@ -1,0 +1,53 @@
+author:
+- Nick Schaub
+- Anjali Taneja
+- Benjamin Houghton
+citation: null
+contact: nick.schaub@nih.gov
+container: polusai/imagej-threshold-shanbhag-plugin:0.4.2
+description: Implements Shanbhag's extension of Kapur's Renyi Entropy method.
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Operation to perform
+  io_format:
+  - opName
+  io_type: string
+  name: opName
+  required: true
+- description: Collection to be processed by this plugin
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+name: polusai/ImageJthresholdshanbhag
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: ImageJ threshold shanbhag
+ui:
+- condition: null
+  customType: null
+  description: Operation to perform
+  fields:
+  - ApplyThresholdMethod$Shanbhag
+  key: inputs.opName
+  optional: null
+  title: opName
+  ui_type: select
+- condition: null
+  customType: null
+  description: Collection to be processed by this plugin
+  ext: null
+  key: inputs.inpDir
+  title: inpDir
+  ui_type: path
+version: 0.4.2

--- a/segmentation/polus-imagej-threshold-triangle-plugin/ict.yaml
+++ b/segmentation/polus-imagej-threshold-triangle-plugin/ict.yaml
@@ -1,0 +1,53 @@
+author:
+- Nick Schaub
+- Anjali Taneja
+- Benjamin Houghton
+citation: null
+contact: nick.schaub@nih.gov
+container: polusai/imagej-threshold-triangle-plugin:0.4.2
+description: This plugin implements the triangle threshold method.
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Operation to perform
+  io_format:
+  - opName
+  io_type: string
+  name: opName
+  required: true
+- description: Collection to be processed by this plugin
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+name: polusai/ImageJthresholdtriangle
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: ImageJ threshold triangle
+ui:
+- condition: null
+  customType: null
+  description: Operation to perform
+  fields:
+  - ApplyThresholdMethod$Triangle
+  key: inputs.opName
+  optional: null
+  title: opName
+  ui_type: select
+- condition: null
+  customType: null
+  description: Collection to be processed by this plugin
+  ext: null
+  key: inputs.inpDir
+  title: inpDir
+  ui_type: path
+version: 0.4.2

--- a/segmentation/polus-imagej-threshold-yen-plugin/ict.yaml
+++ b/segmentation/polus-imagej-threshold-yen-plugin/ict.yaml
@@ -1,0 +1,53 @@
+author:
+- Nick Schaub
+- Anjali Taneja
+- Benjamin Houghton
+citation: null
+contact: nick.schaub@nih.gov
+container: polusai/imagej-threshold-yen-plugin:0.4.2
+description: Applies Yen's threshold method to an input collection.
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Operation to perform
+  io_format:
+  - opName
+  io_type: string
+  name: opName
+  required: true
+- description: Collection to be processed by this plugin
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+name: polusai/ImageJthresholdyen
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: ImageJ threshold yen
+ui:
+- condition: null
+  customType: null
+  description: Operation to perform
+  fields:
+  - ApplyThresholdMethod$Yen
+  key: inputs.opName
+  optional: null
+  title: opName
+  ui_type: select
+- condition: null
+  customType: null
+  description: Collection to be processed by this plugin
+  ext: null
+  key: inputs.inpDir
+  title: inpDir
+  ui_type: path
+version: 0.4.2

--- a/segmentation/polus-smp-training-plugin/ict.yaml
+++ b/segmentation/polus-smp-training-plugin/ict.yaml
@@ -1,0 +1,516 @@
+author:
+- Gauhar Bains
+- Najib Ishaq
+- Madhuri Vihani
+- Benjamin Houghton
+citation: null
+contact: gauhar.bains@labshare.org
+container: polusai/smp-training-plugin:0.5.11
+description: Segmentation models training and inference plugin.
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: '''active'' or ''inactive'' for whether to run in inference mode.'
+  io_format:
+  - inferenceMode
+  io_type: string
+  name: inferenceMode
+  required: true
+- description: Collection containing images on which to run inference.
+  io_format:
+  - imagesInferenceDir
+  io_type: path
+  name: imagesInferenceDir
+  required: false
+- description: Filename pattern for images on which to run inference.
+  io_format:
+  - inferencePattern
+  io_type: string
+  name: inferencePattern
+  required: false
+- description: 'Path to a model that was previously trained with this plugin. If starting
+    fresh, you must instead provide: ''modelName'', ''encoderBase'', ''encoderVariant'',
+    ''encoderWeights'', and ''optimizerName''. See the README for available options.'
+  io_format:
+  - pretrainedModel
+  io_type: path
+  name: pretrainedModel
+  required: false
+- description: Model architecture to use. Required if starting fresh.
+  io_format:
+  - modelName
+  io_type: string
+  name: modelName
+  required: false
+- description: The name of the base encoder to use.
+  io_format:
+  - encoderBase
+  io_type: string
+  name: encoderBase
+  required: false
+- description: The name of the specific variant to use.
+  io_format:
+  - encoderVariant
+  io_type: string
+  name: encoderVariant
+  required: false
+- description: The name of the pretrained weights to use.
+  io_format:
+  - encoderWeights
+  io_type: string
+  name: encoderWeights
+  required: false
+- description: Name of optimization algorithm to use for training the model. Required
+    if starting fresh.
+  io_format:
+  - optimizerName
+  io_type: string
+  name: optimizerName
+  required: false
+- description: Size of each batch for training. If left unspecified, we use the maximum
+    possible based on memory constraints.
+  io_format:
+  - batchSize
+  io_type: number
+  name: batchSize
+  required: false
+- description: Collection containing images to use for training.
+  io_format:
+  - imagesTrainDir
+  io_type: path
+  name: imagesTrainDir
+  required: false
+- description: Collection containing labels, i.e. the ground-truth, for the training
+    images.
+  io_format:
+  - labelsTrainDir
+  io_type: path
+  name: labelsTrainDir
+  required: false
+- description: Filename pattern for training images and labels.
+  io_format:
+  - trainPattern
+  io_type: string
+  name: trainPattern
+  required: false
+- description: Collection containing images to use for validation.
+  io_format:
+  - imagesValidDir
+  io_type: path
+  name: imagesValidDir
+  required: false
+- description: Collection containing labels, i.e. the ground-truth, for the validation
+    images.
+  io_format:
+  - labelsValidDir
+  io_type: path
+  name: labelsValidDir
+  required: false
+- description: Filename pattern for validation images and labels.
+  io_format:
+  - validPattern
+  io_type: string
+  name: validPattern
+  required: false
+- description: Which device to use for the model
+  io_format:
+  - device
+  io_type: string
+  name: device
+  required: false
+- description: How often to save model checkpoints
+  io_format:
+  - checkpointFrequency
+  io_type: number
+  name: checkpointFrequency
+  required: false
+- description: Name of loss function to use.
+  io_format:
+  - lossName
+  io_type: string
+  name: lossName
+  required: false
+- description: Maximum number of epochs for which to continue training the model.
+  io_format:
+  - maxEpochs
+  io_type: number
+  name: maxEpochs
+  required: false
+- description: Maximum number of epochs to wait for model to improve.
+  io_format:
+  - patience
+  io_type: number
+  name: patience
+  required: false
+- description: Minimum improvement in loss to reset patience.
+  io_format:
+  - minDelta
+  io_type: number
+  name: minDelta
+  required: false
+name: polusai/SegmentationModelsTrainingandInference
+outputs:
+- description: In training mode, this contains the trained model and checkpoints.
+    In inference mode, this contains the output labels.
+  io_format:
+  - outputDir
+  io_type: path
+  name: outputDir
+  required: true
+repository: https://github.com/PolusAI/polus-plugins/tree/dev/segmentation
+specVersion: 1.0.0
+title: Segmentation Models Training and Inference
+ui:
+- condition: null
+  customType: null
+  description: '''active'' or ''inactive'' for whether to run in inference mode.'
+  fields:
+  - active
+  - inactive
+  key: inputs.inferenceMode
+  optional: null
+  title: inferenceMode
+  ui_type: select
+- condition: inputs.inferenceMode==active
+  customType: null
+  description: Collection containing images on which to run inference.
+  ext: null
+  key: inputs.imagesInferenceDir
+  title: imagesInferenceDir
+  ui_type: path
+- condition: inputs.inferenceMode==active
+  customType: null
+  default: null
+  description: Filename pattern for images on which to run inference.
+  key: inputs.inferencePattern
+  regex: null
+  title: inferencePattern
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  description: 'Path to a model that was previously trained with this plugin. If starting
+    fresh, you must instead provide: ''modelName'', ''encoderBase'', ''encoderVariant'',
+    ''encoderWeights'', and ''optimizerName''. See the README for available options.'
+  ext: null
+  key: inputs.pretrainedModel
+  title: pretrainedModel
+  ui_type: path
+- condition: null
+  customType: null
+  description: Model architecture to use. Required if starting fresh.
+  fields:
+  - Unet
+  - UnetPlusPlus
+  - MAnet
+  - Linknet
+  - FPN
+  - PSPNet
+  - PAN
+  - DeepLabV3
+  - DeepLabV3Plus
+  key: inputs.modelName
+  optional: null
+  title: modelName
+  ui_type: select
+- condition: null
+  customType: null
+  description: The name of the base encoder to use.
+  fields:
+  - ResNet
+  - ResNeXt
+  - ResNeSt
+  - Res2Ne(X)t
+  - RegNet(x/y)
+  - GERNet
+  - SE-Net
+  - SK-ResNe(X)t
+  - DenseNet
+  - Inception
+  - EfficientNet
+  - MobileNet
+  - DPN
+  - VGG
+  key: inputs.encoderBase
+  optional: null
+  title: encoderBase
+  ui_type: select
+- condition: null
+  customType: null
+  description: The name of the specific variant to use.
+  fields:
+  - resnet18
+  - resnet34
+  - resnet50
+  - resnet101
+  - resnet152
+  - resnext50_32x4d
+  - resnext101_32x4d
+  - resnext101_32x8d
+  - resnext101_32x16d
+  - resnext101_32x32d
+  - resnext101_32x48d
+  - timm-resnest14d
+  - timm-resnest26d
+  - timm-resnest50d
+  - timm-resnest101e
+  - timm-resnest200e
+  - timm-resnest269e
+  - timm-resnest50d_4s2x40d
+  - timm-resnest50d_1s4x24d
+  - timm-res2net50_26w_4s
+  - timm-res2net101_26w_4s
+  - timm-res2net50_26w_6s
+  - timm-res2net50_26w_8s
+  - timm-res2net50_48w_2s
+  - timm-res2net50_14w_8s
+  - timm-res2next50
+  - timm-regnetx_002
+  - timm-regnetx_004
+  - timm-regnetx_006
+  - timm-regnetx_008
+  - timm-regnetx_016
+  - timm-regnetx_032
+  - timm-regnetx_040
+  - timm-regnetx_064
+  - timm-regnetx_080
+  - timm-regnetx_120
+  - timm-regnetx_160
+  - timm-regnetx_320
+  - timm-regnety_002
+  - timm-regnety_004
+  - timm-regnety_006
+  - timm-regnety_008
+  - timm-regnety_016
+  - timm-regnety_032
+  - timm-regnety_040
+  - timm-regnety_064
+  - timm-regnety_080
+  - timm-regnety_120
+  - timm-regnety_160
+  - timm-regnety_320
+  - timm-gernet_s
+  - timm-gernet_m
+  - timm-gernet_l
+  - senet154
+  - se_resnet50
+  - se_resnet101
+  - se_resnet152
+  - se_resnext50_32x4d
+  - se_resnext101_32x4d
+  - timm-skresnet18
+  - timm-skresnet34
+  - timm-skresnext50_32x4d
+  - densenet121
+  - densenet169
+  - densenet201
+  - densenet161
+  - inceptionresnetv2
+  - inceptionv4
+  - xception
+  - efficientnet-b0
+  - efficientnet-b1
+  - efficientnet-b2
+  - efficientnet-b3
+  - efficientnet-b4
+  - efficientnet-b5
+  - efficientnet-b6
+  - efficientnet-b7
+  - timm-efficientnet-b0
+  - timm-efficientnet-b1
+  - timm-efficientnet-b2
+  - timm-efficientnet-b3
+  - timm-efficientnet-b4
+  - timm-efficientnet-b5
+  - timm-efficientnet-b6
+  - timm-efficientnet-b7
+  - timm-efficientnet-b8
+  - timm-efficientnet-l2
+  - timm-efficientnet-lite0
+  - timm-efficientnet-lite1
+  - timm-efficientnet-lite2
+  - timm-efficientnet-lite3
+  - timm-efficientnet-lite4
+  - mobilenet_v2
+  - timm-mobilenetv3_large_075
+  - timm-mobilenetv3_large_100
+  - timm-mobilenetv3_large_minimal_100
+  - timm-mobilenetv3_small_075
+  - timm-mobilenetv3_small_100
+  - timm-mobilenetv3_small_minimal_100
+  - dpn68
+  - dpn68b
+  - dpn92
+  - dpn98
+  - dpn107
+  - dpn131
+  - vgg11
+  - vgg11_bn
+  - vgg13
+  - vgg13_bn
+  - vgg16
+  - vgg16_bn
+  - vgg19
+  - vgg19_bn
+  key: inputs.encoderVariant
+  optional: null
+  title: encoderVariant
+  ui_type: select
+- condition: null
+  customType: null
+  description: The name of the pretrained weights to use.
+  fields:
+  - advprop
+  - imagenet
+  - imagenet+5k
+  - imagenet+background
+  - instagram
+  - noisy-student
+  - random
+  - ssl
+  - swsl
+  key: inputs.encoderWeights
+  optional: null
+  title: encoderWeights
+  ui_type: select
+- condition: inputs.inferenceMode==inactive
+  customType: null
+  description: Name of optimization algorithm to use for training the model. Required
+    if starting fresh.
+  fields:
+  - Adadelta
+  - Adagrad
+  - Adam
+  - AdamW
+  - SparseAdam
+  - Adamax
+  - ASGD
+  - LBFGS
+  - RMSprop
+  - Rprop
+  - SGD
+  key: inputs.optimizerName
+  optional: null
+  title: optimizerName
+  ui_type: select
+- condition: inputs.inferenceMode==inactive
+  customType: null
+  default: null
+  description: Size of each batch for training. If left unspecified, we use the maximum
+    possible based on memory constraints.
+  integer: null
+  key: inputs.batchSize
+  number_range: null
+  title: batchSize
+  ui_type: number
+- condition: inputs.inferenceMode==inactive
+  customType: null
+  description: Collection containing images to use for training.
+  ext: null
+  key: inputs.imagesTrainDir
+  title: imagesTrainDir
+  ui_type: path
+- condition: inputs.inferenceMode==inactive
+  customType: null
+  description: Collection containing labels, i.e. the ground-truth, for the training
+    images.
+  ext: null
+  key: inputs.labelsTrainDir
+  title: labelsTrainDir
+  ui_type: path
+- condition: inputs.inferenceMode==inactive
+  customType: null
+  default: null
+  description: Filename pattern for training images and labels.
+  key: inputs.trainPattern
+  regex: null
+  title: trainPattern
+  toolbar: null
+  ui_type: text
+- condition: inputs.inferenceMode==inactive
+  customType: null
+  description: Collection containing images to use for validation.
+  ext: null
+  key: inputs.imagesValidDir
+  title: imagesValidDir
+  ui_type: path
+- condition: inputs.inferenceMode==inactive
+  customType: null
+  description: Collection containing labels, i.e. the ground-truth, for the validation
+    images.
+  ext: null
+  key: inputs.labelsValidDir
+  title: labelsValidDir
+  ui_type: path
+- condition: inputs.inferenceMode==inactive
+  customType: null
+  default: null
+  description: Filename pattern for validation images and labels.
+  key: inputs.validPattern
+  regex: null
+  title: validPattern
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  default: null
+  description: Which device to use for the model
+  key: inputs.device
+  regex: null
+  title: device
+  toolbar: null
+  ui_type: text
+- condition: inputs.inferenceMode==inactive
+  customType: null
+  default: null
+  description: How often to save model checkpoints
+  integer: null
+  key: inputs.checkpointFrequency
+  number_range: null
+  title: checkpointFrequency
+  ui_type: number
+- condition: inputs.inferenceMode==inactive
+  customType: null
+  description: Name of loss function to use.
+  fields:
+  - JaccardLoss
+  - DiceLoss
+  - TverskyLoss
+  - FocalLoss
+  - LovaszLoss
+  - SoftBCEWithLogitsLoss
+  - SoftCrossEntropyLoss
+  - MCCLoss
+  key: inputs.lossName
+  optional: null
+  title: lossName
+  ui_type: select
+- condition: inputs.inferenceMode==inactive
+  customType: null
+  default: 100
+  description: Maximum number of epochs for which to continue training the model.
+  integer: null
+  key: inputs.maxEpochs
+  number_range: null
+  title: maxEpochs
+  ui_type: number
+- condition: inputs.inferenceMode==inactive
+  customType: null
+  default: 10
+  description: Maximum number of epochs to wait for model to improve.
+  integer: null
+  key: inputs.patience
+  number_range: null
+  title: patience
+  ui_type: number
+- condition: inputs.inferenceMode==inactive
+  customType: null
+  default: 0.0001
+  description: Minimum improvement in loss to reset patience.
+  integer: null
+  key: inputs.minDelta
+  number_range: null
+  title: minDelta
+  ui_type: number
+version: 0.5.11

--- a/to_ict.py
+++ b/to_ict.py
@@ -1,0 +1,87 @@
+# ruff: noqa
+"""Script to convert all WIPP manifests to ICT."""
+
+# pylint: disable=W0718, W1203
+import logging
+from pathlib import Path
+
+import typer
+from ict import ICT
+from tqdm import tqdm
+
+app = typer.Typer(help="Convert WIPP manifests to ICT.")
+ict_logger = logging.getLogger("ict")
+ict_logger.setLevel(logging.INFO)
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+    datefmt="%m/%d/%Y %I:%M:%S %p",
+)
+logger = logging.getLogger("wipp_to_ict")
+
+REPO_PATH = Path(__file__).parent
+LOCAL_MANIFESTS = list(REPO_PATH.rglob("*plugin.json"))
+logger.info(f"Found {len(LOCAL_MANIFESTS)} manifests in {REPO_PATH}")
+IGNORE_LIST = ["cookiecutter", ".env", "Shared-Memory-OpenMP"]
+# Shared-Memory-OpenMP ignored for now until version
+# and container are fixed in the manifest
+LOCAL_MANIFESTS = [
+    x for x in LOCAL_MANIFESTS if not any(ig in str(x) for ig in IGNORE_LIST)
+]
+
+
+@app.command()
+def main(
+    all_: bool = typer.Option(
+        False,
+        "--all",
+        "-a",
+        help="Convert all manifests in the repository.",
+    ),
+    name: str = typer.Option(
+        None,
+        "--name",
+        "-n",
+        help="Name of the plugin to convert.",
+    ),
+) -> None:
+    """Convert WIPP manifests to ICT."""
+    problems = {}
+    converted = 0
+    if not all_ and name is None:
+        logger.error("Please provide a name if not converting all manifests.")
+        raise typer.Abort
+    if name is not None:
+        if all_:
+            logger.warning("Ignoring --all flag since a name was provided.")
+        logger.info(f"name: {name}")
+        all_ = False
+    logger.info(f"all: {all_}")
+    if all_:
+        n = len(LOCAL_MANIFESTS)
+        for manifest in tqdm(LOCAL_MANIFESTS):
+            try:
+                ict_ = ICT.from_wipp(manifest)
+                ict_.save_yaml(manifest.with_name("ict.yaml"))
+                converted += 1
+
+            except BaseException as e:
+                problems[Path(manifest).parts[4:-1]] = str(e)
+    if name is not None:
+        n = 1
+        for manifest in [x for x in LOCAL_MANIFESTS if name in str(x)]:
+            try:
+                ict_ = ICT.from_wipp(manifest)
+                ict_.save_yaml(manifest.with_name("ict.yaml"))
+                converted += 1
+
+            except BaseException as e:
+                problems[Path(manifest).parts[4:-1]] = str(e)
+
+    logger.info(f"Converted {converted}/{n} plugins")
+    if len(problems) > 0:
+        logger.error(f"Problems: {problems}")
+
+
+if __name__ == "__main__":
+    app()

--- a/transforms/images/apply-flatfield-tool/ict.yaml
+++ b/transforms/images/apply-flatfield-tool/ict.yaml
@@ -1,0 +1,108 @@
+author:
+- Nick Schaub
+- Najib Ishaq
+citation: null
+contact: Nick.Schaub@nih.gov
+container: polusai/apply-flatfield-tool:2.0.1-dev0
+description: Apply a flatfield algorithm to a collection of images.
+documentation: null
+entrypoint: python3 -m polus.images.transforms.images.apply_flatfield
+hardware: null
+inputs:
+- description: Input image collection to be processed by this plugin
+  io_format:
+  - imgDir
+  io_type: path
+  name: imgDir
+  required: true
+- description: Filename pattern used to separate data and match with flatfied files
+  io_format:
+  - imgPattern
+  io_type: string
+  name: imgPattern
+  required: true
+- description: Image collection containing flatfield and/or darkfield images
+  io_format:
+  - ffDir
+  io_type: path
+  name: ffDir
+  required: true
+- description: Filename pattern used to match flatfield files to image files
+  io_format:
+  - ffPattern
+  io_type: string
+  name: ffPattern
+  required: true
+- description: Filename pattern used to match darkfield files to image files
+  io_format:
+  - dfPattern
+  io_type: string
+  name: dfPattern
+  required: false
+- description: Preview the output images' names without actually running computation
+  io_format:
+  - preview
+  io_type: boolean
+  name: preview
+  required: false
+name: polusai/ApplyFlatfield
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: Apply Flatfield
+ui:
+- condition: null
+  customType: null
+  description: Input image collection to be processed by this plugin
+  ext: null
+  key: inputs.imgDir
+  title: Images to correct
+  ui_type: path
+- condition: null
+  customType: null
+  default: null
+  description: Filename pattern used to separate data and match with flatfield files
+  key: inputs.imgPattern
+  regex: null
+  title: Image pattern
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  description: Image collection containing flatfield and/or darkfield images
+  ext: null
+  key: inputs.ffDir
+  title: Background images (flatfield/darkfield)
+  ui_type: path
+- condition: null
+  customType: null
+  default: null
+  description: Filename pattern used to match flatfield files to image files
+  key: inputs.ffPattern
+  regex: null
+  title: Flatfield file pattern
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  default: null
+  description: Filename pattern used to match darkfield files to image files
+  key: inputs.dfPattern
+  regex: null
+  title: Darkfield file pattern
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  default: null
+  description: Preview the output images' names without actually running computation
+  key: inputs.preview
+  title: Preview Output
+  ui_type: checkbox
+version: 2.0.1-dev0

--- a/transforms/images/binary-operations-tool/ict.yaml
+++ b/transforms/images/binary-operations-tool/ict.yaml
@@ -1,0 +1,140 @@
+author:
+- Nick Schaub
+- Madhuri Vihani
+citation: null
+contact: nick.schaub@nih.gov
+container: polusai/binary-operations-tool:0.5.3-dev0
+description: Everything you need to start a WIPP plugin.
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Input image collection to be processed by this plugin
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+- description: Pattern of the images in Input
+  io_format:
+  - filePattern
+  io_type: string
+  name: filePattern
+  required: false
+- description: Kernel size that should be used for transformation
+  io_format:
+  - kernel
+  io_type: number
+  name: kernel
+  required: false
+- description: The Binary Operations that will be done on the image
+  io_format:
+  - operation
+  io_type: string
+  name: operation
+  required: true
+- description: Structuring Shape (Default is Elliptical)
+  io_format:
+  - shape
+  io_type: string
+  name: shape
+  required: false
+- description: Minimum Area of objects to keep.
+  io_format:
+  - threshold
+  io_type: number
+  name: threshold
+  required: false
+- description: Number of times to perform an operation (when applicable).
+  io_format:
+  - iterations
+  io_type: number
+  name: iterations
+  required: false
+name: polusai/BinaryOperationsPlugin
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/polusai/polus-plugins
+specVersion: 1.0.0
+title: Binary Operations Plugin
+ui:
+- condition: null
+  customType: null
+  description: Operations that will be used on image
+  fields:
+  - blackhat
+  - close
+  - dilate
+  - erode
+  - fillHoles
+  - invert
+  - morphologicalGradient
+  - open
+  - removeLarge
+  - removeSmall
+  - skeleton
+  - tophat
+  key: inputs.operation
+  optional: null
+  title: Operations
+  ui_type: select
+- condition: null
+  customType: null
+  default: null
+  description: 'Pattern of images in input collection (image_r{rrr}_c{ccc}_z{zzz}.ome.tif). '
+  key: inputs.filePattern
+  regex: null
+  title: 'Image Pattern: '
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  description: Input image collection to be processed by this plugin
+  ext: null
+  key: inputs.inpDir
+  title: Input collection
+  ui_type: path
+- condition: null
+  customType: null
+  default: null
+  description: Kernel size to use for operations
+  integer: null
+  key: inputs.kernel
+  number_range: null
+  title: Kernel Size
+  ui_type: number
+- condition: null
+  customType: null
+  description: Kernel shape to use for operations
+  fields:
+  - ellipse
+  - rect
+  - cross
+  key: inputs.shape
+  optional: null
+  title: Structuring Shape (Default is Elliptical)
+  ui_type: select
+- condition: null
+  customType: null
+  default: null
+  description: Threshold to use for operations
+  integer: null
+  key: inputs.threshold
+  number_range: null
+  title: Threshold of area for objects in images
+  ui_type: number
+- condition: null
+  customType: null
+  default: null
+  description: Number of iterations to perform
+  integer: null
+  key: inputs.iterations
+  number_range: null
+  title: Iterations
+  ui_type: number
+version: 0.5.3-dev0

--- a/transforms/images/binary-operations-tool/plugin.json
+++ b/transforms/images/binary-operations-tool/plugin.json
@@ -4,7 +4,7 @@
   "containerId": "polusai/binary-operations-tool:0.5.3-dev0",
   "title": "Binary Operations Plugin",
   "description": "Everything you need to start a WIPP plugin.",
-  "authors": "nicholas-schaub (nick.schaub@nih.gov), Madhuri Vihani",
+  "author": "Nick Schaub (nick.schaub@nih.gov), Madhuri Vihani",
   "institution": "National Center for Advancing Translational Sciences, National Institutes of Health",
   "repository": "https://github.com/polusai/polus-plugins",
   "website": "https://ncats.nih.gov/preclinical/core/informatics",

--- a/transforms/images/image-assembler-tool/ict.yaml
+++ b/transforms/images/image-assembler-tool/ict.yaml
@@ -1,0 +1,69 @@
+author:
+- Nick Schaub
+- Antoine Gerardin
+citation: null
+contact: nick.schaub@nih.gov
+container: polusai/image-assembler-tool:1.4.1-dev0
+description: A scalable image assembling plugin.
+documentation: null
+entrypoint: python3 -m polus.images.transforms.images.image_assembler
+hardware: null
+inputs:
+- description: Stitching vector for data
+  io_format:
+  - stitchPath
+  io_type: path
+  name: stitchPath
+  required: true
+- description: Input image collection to be processed by this plugin
+  io_format:
+  - imgPath
+  io_type: path
+  name: imgPath
+  required: true
+- description: Label images by timeslice rather than analyzing input image names
+  io_format:
+  - timesliceNaming
+  io_type: boolean
+  name: timesliceNaming
+  required: false
+- description: Generate preview of outputs.
+  io_format:
+  - preview
+  io_type: boolean
+  name: preview
+  required: false
+name: polusai/ImageAssembler
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: Image Assembler
+ui:
+- condition: null
+  customType: null
+  description: Input image collection to be processed by this plugin
+  ext: null
+  key: inputs.imgPath
+  title: Input collection
+  ui_type: path
+- condition: null
+  customType: null
+  description: Stitching vectors to use
+  ext: null
+  key: inputs.stitchPath
+  title: Stitching Vector
+  ui_type: path
+- condition: null
+  customType: null
+  default: null
+  description: Use stitching vector timeslice number as the image name
+  key: inputs.timesliceNaming
+  title: 'Timeslice numbers for image names:'
+  ui_type: checkbox
+version: 1.4.1-dev0

--- a/transforms/images/image-calculator-tool/ict.yaml
+++ b/transforms/images/image-calculator-tool/ict.yaml
@@ -1,0 +1,103 @@
+author:
+- Nick Schaub
+citation: null
+contact: nick.schaub@nih.gov
+container: polusai/image-calculator-tool:0.2.2-dev0
+description: Perform simple mathematical operations on images.
+documentation: null
+entrypoint: python3 -m polus.images.transforms.images.image_calculator
+hardware: null
+inputs:
+- description: The first set of images
+  io_format:
+  - primaryDir
+  io_type: path
+  name: primaryDir
+  required: true
+- description: Filename pattern used to separate data
+  io_format:
+  - primaryPattern
+  io_type: string
+  name: primaryPattern
+  required: false
+- description: The operation to perform
+  io_format:
+  - operator
+  io_type: string
+  name: operator
+  required: true
+- description: The second set of images
+  io_format:
+  - secondaryDir
+  io_type: path
+  name: secondaryDir
+  required: true
+- description: Filename pattern used to separate data
+  io_format:
+  - secondaryPattern
+  io_type: string
+  name: secondaryPattern
+  required: false
+name: polusai/ImageCalculator
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: Image Calculator
+ui:
+- condition: null
+  customType: null
+  description: The first set of images
+  ext: null
+  key: inputs.primaryDir
+  title: First image collection
+  ui_type: path
+- condition: null
+  customType: null
+  default: null
+  description: Filename pattern used to separate data
+  key: inputs.primaryPattern
+  regex: null
+  title: Filename pattern
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  description: The operation to perform
+  fields:
+  - add
+  - subtract
+  - multiply
+  - divide
+  - and
+  - or
+  - xor
+  - min
+  - max
+  - absdiff
+  key: inputs.operator
+  optional: null
+  title: Operation
+  ui_type: select
+- condition: null
+  customType: null
+  description: The second set of images
+  ext: null
+  key: inputs.secondaryDir
+  title: Second image collection
+  ui_type: path
+- condition: null
+  customType: null
+  default: null
+  description: Filename pattern used to separate data
+  key: inputs.secondaryPattern
+  regex: null
+  title: Filename pattern
+  toolbar: null
+  ui_type: text
+version: 0.2.2-dev0

--- a/transforms/images/lumos-bleedthrough-correction-tool/ict.yaml
+++ b/transforms/images/lumos-bleedthrough-correction-tool/ict.yaml
@@ -1,0 +1,81 @@
+author:
+- Najib Ishaq
+citation: null
+contact: najib.ishaq@nih.gov
+container: polusai/lumos-bleedthrough-correction-tool:0.1.2-dev0
+description: LUMoS Algorithm for bleedthrough correction.
+documentation: null
+entrypoint: python3 -m polus.images.transforms.images.lumos_bleedthrough_correction
+hardware: null
+inputs:
+- description: Input image collection to be processed by this plugin.
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+- description: Filepattern for the images.
+  io_format:
+  - filePattern
+  io_type: string
+  name: filePattern
+  required: true
+- description: Grouping variables for images.
+  io_format:
+  - groupBy
+  io_type: string
+  name: groupBy
+  required: true
+- description: Number of fluorophores in the images.
+  io_format:
+  - numFluorophores
+  io_type: number
+  name: numFluorophores
+  required: true
+name: polusai/LUMoSBleedthroughCorrectionPlugin
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/PolusAI/polus-plugins/transforms/images/lumos-bleedthrough-correction-plugin
+specVersion: 1.0.0
+title: LUMoS Bleedthrough Correction Plugin
+ui:
+- condition: null
+  customType: null
+  description: Input image collection to be processed by this plugin.
+  ext: null
+  key: inputs.inpDir
+  title: Input collection
+  ui_type: path
+- condition: null
+  customType: null
+  default: null
+  description: Filepattern for the images.
+  key: inputs.filePattern
+  regex: null
+  title: filePattern
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  default: null
+  description: Grouping variables for images.
+  key: inputs.groupBy
+  regex: null
+  title: groupBy
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  default: null
+  description: Number of fluorophores in the images.
+  integer: null
+  key: inputs.numFluorophores
+  number_range: null
+  title: numFluorophores
+  ui_type: number
+version: 0.1.2-dev0

--- a/transforms/images/montage-tool/ict.yaml
+++ b/transforms/images/montage-tool/ict.yaml
@@ -1,0 +1,112 @@
+author:
+- Nick Schaub
+- Benjamin Houghton
+citation: null
+contact: nick.schaub@nih.gov
+container: polusai/montage-tool:0.5.1-dev0
+description: Advanced montaging plugin.
+documentation: null
+entrypoint: python3 -m polus.images.transforms.images.montage
+hardware: null
+inputs:
+- description: Filename pattern used to parse data
+  io_format:
+  - filePattern
+  io_type: string
+  name: filePattern
+  required: true
+- description: Input image collection to be processed by this plugin
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+- description: Specify montage organization
+  io_format:
+  - layout
+  io_type: array
+  name: layout
+  required: false
+- description: Spacing between images at the lowest subgrid
+  io_format:
+  - imageSpacing
+  io_type: number
+  name: imageSpacing
+  required: false
+- description: Input image collection to be processed by this plugin
+  io_format:
+  - gridSpacing
+  io_type: number
+  name: gridSpacing
+  required: false
+- description: Axes to flip when creating the montage
+  io_format:
+  - flipAxis
+  io_type: string
+  name: flipAxis
+  required: false
+name: polusai/Montage
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/PolusAI/polus-plugins
+specVersion: 1.0.0
+title: Montage
+ui:
+- condition: null
+  customType: null
+  default: null
+  description: Filename pattern used to parse data
+  key: inputs.filePattern
+  regex: null
+  title: Filename pattern
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  description: Input image collection to be processed by this plugin
+  ext: null
+  key: inputs.inpDir
+  title: Input collection
+  ui_type: path
+- condition: null
+  customType: null
+  default: null
+  description: Specify montage organization
+  key: inputs.layout
+  regex: null
+  title: Grid layout
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  default: null
+  description: Space between images
+  integer: null
+  key: inputs.imageSpacing
+  number_range: null
+  title: Image spacing
+  ui_type: number
+- condition: null
+  customType: null
+  default: null
+  description: Spacing between subgrids
+  integer: null
+  key: inputs.gridSpacing
+  number_range: null
+  title: Grid spacing multiplier
+  ui_type: number
+- condition: null
+  customType: null
+  default: null
+  description: Axes to flip when laying out images.
+  key: inputs.flipAxis
+  regex: null
+  title: Flip Axis
+  toolbar: null
+  ui_type: text
+version: 0.5.1-dev0

--- a/transforms/images/polus-apply-flatfield-plugin/ict.yaml
+++ b/transforms/images/polus-apply-flatfield-plugin/ict.yaml
@@ -1,0 +1,109 @@
+author:
+- Nick Schaub
+citation: null
+contact: Nick.Schaub@nih.gov
+container: polusai/apply-flatfield-plugin:1.2.0
+description: Apply a flatfield algorithm to a collection of images.
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Filename pattern used to match darkfield files to image files
+  io_format:
+  - darkPattern
+  io_type: string
+  name: darkPattern
+  required: false
+- description: Image collection containing flatfield and/or darkfield images
+  io_format:
+  - ffDir
+  io_type: path
+  name: ffDir
+  required: true
+- description: Filename pattern used to match brightfield files to image files
+  io_format:
+  - brightPattern
+  io_type: string
+  name: brightPattern
+  required: true
+- description: Input image collection to be processed by this plugin
+  io_format:
+  - imgDir
+  io_type: path
+  name: imgDir
+  required: true
+- description: Filename pattern used to separate data and match with flatfied files
+  io_format:
+  - imgPattern
+  io_type: string
+  name: imgPattern
+  required: true
+- description: Filename pattern used to match photobleach files to image files
+  io_format:
+  - photoPattern
+  io_type: string
+  name: photoPattern
+  required: true
+name: polusai/ApplyFlatfield
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: Apply Flatfield
+ui:
+- condition: null
+  customType: null
+  description: Input image collection to be processed by this plugin
+  ext: null
+  key: inputs.imgDir
+  title: Images to correct
+  ui_type: path
+- condition: null
+  customType: null
+  default: null
+  description: Filename pattern used to separate data and match with flatfied files
+  key: inputs.imgPattern
+  regex: null
+  title: Image pattern
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  description: Image collection containing flatfield and/or darkfield images
+  ext: null
+  key: inputs.ffDir
+  title: Background images (flatfield/darkfield)
+  ui_type: path
+- condition: null
+  customType: null
+  default: null
+  description: Filename pattern used to match brightfield files to image files
+  key: inputs.brightPattern
+  regex: null
+  title: Brightfield file pattern
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  default: null
+  description: Filename pattern used to match darkfield files to image files
+  key: inputs.darkPattern
+  regex: null
+  title: Darkfield file pattern
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  default: null
+  description: Filename pattern used to match photobleach files to image files
+  key: inputs.photoPattern
+  regex: null
+  title: Photobleach file pattern
+  toolbar: null
+  ui_type: text
+version: 1.2.0

--- a/transforms/images/polus-autocropping-plugin/ict.yaml
+++ b/transforms/images/polus-autocropping-plugin/ict.yaml
@@ -1,0 +1,121 @@
+author:
+- Najib Ishaq
+citation: null
+contact: najib.ishaq@axleinfo.com
+container: polusai/autocropping-plugin:1.0.2
+description: Automatically remove noise and other useless sections from images.
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Input image collection to be processed by this plugin.
+  io_format:
+  - inputDir
+  io_type: path
+  name: inputDir
+  required: true
+- description: File pattern to use for grouping images.
+  io_format:
+  - filePattern
+  io_type: string
+  name: filePattern
+  required: true
+- description: Grouping variables for images.
+  io_format:
+  - groupBy
+  io_type: string
+  name: groupBy
+  required: true
+- description: Whether to crop along the x-axis
+  io_format:
+  - cropX
+  io_type: boolean
+  name: cropX
+  required: false
+- description: Whether to crop along the y-axis
+  io_format:
+  - cropY
+  io_type: boolean
+  name: cropY
+  required: false
+- description: Whether to crop along the z-axis
+  io_format:
+  - cropZ
+  io_type: boolean
+  name: cropZ
+  required: false
+- description: Whether to use gaussian smoothing on images to add more tolerance to
+    noise.
+  io_format:
+  - smoothing
+  io_type: boolean
+  name: smoothing
+  required: false
+name: polusai/Autocropping
+outputs:
+- description: Output collection
+  io_format:
+  - outputDir
+  io_type: path
+  name: outputDir
+  required: true
+repository: https://github.com/PolusAI/polus-plugins/transforms/images/polus-autocropping-plugin
+specVersion: 1.0.0
+title: Autocropping
+ui:
+- condition: null
+  customType: null
+  description: Input image collection to be processed by this plugin.
+  ext: null
+  key: inputs.inputDir
+  title: Input collection
+  ui_type: path
+- condition: null
+  customType: null
+  default: null
+  description: File pattern to use for grouping images.
+  key: inputs.filePattern
+  regex: null
+  title: File Pattern
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  default: null
+  description: Variables to use for grouping images. Each group is cropped to the
+    same bounding-box.
+  key: inputs.groupBy
+  regex: null
+  title: Grouping Variables
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  default: true
+  description: Whether to crop along the x-axis
+  key: inputs.cropX
+  title: Crop X
+  ui_type: checkbox
+- condition: null
+  customType: null
+  default: true
+  description: Whether to crop along the y-axis
+  key: inputs.cropY
+  title: Crop Y
+  ui_type: checkbox
+- condition: null
+  customType: null
+  default: true
+  description: Whether to crop along the z-axis
+  key: inputs.cropZ
+  title: Crop Z
+  ui_type: checkbox
+- condition: null
+  customType: null
+  default: true
+  description: Whether to use gaussian smoothing on images to add more tolerance to
+    noise.
+  key: inputs.smoothing
+  title: Smoothing
+  ui_type: checkbox
+version: 1.0.2

--- a/transforms/images/polus-autocropping-plugin/plugin.json
+++ b/transforms/images/polus-autocropping-plugin/plugin.json
@@ -77,19 +77,22 @@
       "description": "Variables to use for grouping images. Each group is cropped to the same bounding-box."
     },
     {
-      "name": "inputs.cropX",
+      "key": "inputs.cropX",
+      "title": "Crop X",
       "type": "boolean",
       "description": "Whether to crop along the x-axis",
       "default": "true"
     },
     {
-      "name": "inputs.cropY",
+      "key": "inputs.cropY",
+      "title": "Crop Y",
       "type": "boolean",
       "description": "Whether to crop along the y-axis",
       "default": "true"
     },
     {
-      "name": "inputs.cropZ",
+      "key": "inputs.cropZ",
+      "title": "Crop Z",
       "type": "boolean",
       "description": "Whether to crop along the z-axis",
       "default": "true"

--- a/transforms/images/polus-ftl-label-plugin/ict.yaml
+++ b/transforms/images/polus-ftl-label-plugin/ict.yaml
@@ -1,0 +1,52 @@
+author:
+- Nick Schaub
+- Najib Ishaq
+citation: null
+contact: nick.schaub@nih.gov
+container: labshare/polus-ftl-label-plugin:0.3.8
+description: Label objects in a 2d or 3d binary image.
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Input image collection to be processed by this plugin
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+- description: City block connectivity
+  io_format:
+  - connectivity
+  io_type: number
+  name: connectivity
+  required: true
+name: labshare/FTLLabel
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: FTL Label
+ui:
+- condition: null
+  customType: null
+  description: Input image collection to be processed by this plugin
+  ext: null
+  key: inputs.inpDir
+  title: Input collection
+  ui_type: path
+- condition: null
+  customType: null
+  default: null
+  description: City block connectivity
+  integer: null
+  key: inputs.connectivity
+  number_range: null
+  title: Connectivity
+  ui_type: number
+version: 0.3.9

--- a/transforms/images/polus-image-registration-plugin/ict.yaml
+++ b/transforms/images/polus-image-registration-plugin/ict.yaml
@@ -1,0 +1,118 @@
+author:
+- Gauhar Bains
+- Nick Schaub
+citation: null
+contact: gauhar.bains@labshare.org
+container: polusai/image-registration-plugin:0.3.5
+description: This plugin registers an image collection
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Input image collection to be processed by this plugin
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+- description: Filename pattern used to separate data
+  io_format:
+  - filePattern
+  io_type: string
+  name: filePattern
+  required: true
+- description: Template image to be used for image registration
+  io_format:
+  - template
+  io_type: string
+  name: template
+  required: true
+- description: variable to help identify which images need to be registered to each
+    other
+  io_format:
+  - registrationVariable
+  io_type: string
+  name: registrationVariable
+  required: true
+- description: variable to help identify which images have similar transformation
+  io_format:
+  - TransformationVariable
+  io_type: string
+  name: TransformationVariable
+  required: true
+- description: Projective (8 degrees of freedom), Affine (6 degrees of freedom), Partial
+    Affine (4 degrees of freedom)
+  io_format:
+  - method
+  io_type: string
+  name: method
+  required: true
+name: polusai/ImageRegistration
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: Image Registration
+ui:
+- condition: null
+  customType: null
+  description: Input image collection to be processed by this plugin
+  ext: null
+  key: inputs.inpDir
+  title: Input collection
+  ui_type: path
+- condition: null
+  customType: null
+  default: null
+  description: Filename pattern used to separate data
+  key: inputs.filePattern
+  regex: null
+  title: Filename pattern
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  default: null
+  description: Template image to be used for image registration
+  key: inputs.template
+  regex: null
+  title: Template Image
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  default: null
+  description: variable to help identify which images need to be registered to each
+    other
+  key: inputs.registrationVariable
+  regex: null
+  title: Registration Variable
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  default: null
+  description: variable to help identify which images have similar transformation
+  key: inputs.TransformationVariable
+  regex: null
+  title: Similar Transformation Variable
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  description: Projective (8 degrees of freedom), Affine (6 degrees of freedom), Partial
+    Affine (4 degrees of freedom)
+  fields:
+  - Projective
+  - Affine
+  - PartialAffine
+  key: inputs.method
+  optional: null
+  title: Deformation method
+  ui_type: select
+version: 0.3.5

--- a/transforms/images/polus-imagej-deconvolve-richardsonlucy-plugin/ict.yaml
+++ b/transforms/images/polus-imagej-deconvolve-richardsonlucy-plugin/ict.yaml
@@ -1,0 +1,80 @@
+author:
+- Benjamin Houghton
+citation: null
+contact: benjamin.houghton@axleinfo.com
+container: polusai/imagej-deconvolve-richardsonlucy-plugin:0.4.3
+description: This plugin applies the Richardson-Lucy Deconvolution to input collection.
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Op overloading method to perform
+  io_format:
+  - opName
+  io_type: string
+  name: opName
+  required: false
+- description: Input collection to be processed by this plugin
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: false
+- description: The point spread function mask to be used
+  io_format:
+  - psf
+  io_type: path
+  name: psf
+  required: false
+- description: The maximum number of algorithm iterations
+  io_format:
+  - maxIterations
+  io_type: number
+  name: maxIterations
+  required: false
+name: polusai/ImageJdeconvolverichardsonLucy
+outputs:
+- description: The output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: ImageJ deconvolve richardsonLucy
+ui:
+- condition: null
+  customType: null
+  description: Op overloading method to perform
+  fields:
+  - PadAndRichardsonLucy
+  - RichardsonLucyC
+  key: inputs.opName
+  optional: null
+  title: opName
+  ui_type: select
+- condition: inputs.opName==RichardsonLucyC
+  customType: null
+  description: Input collection to be processed by this plugin
+  ext: null
+  key: inputs.inpDir
+  title: inpDir
+  ui_type: path
+- condition: inputs.opName==RichardsonLucyC
+  customType: null
+  description: The point spread function mask to be used
+  ext: null
+  key: inputs.psf
+  title: psf
+  ui_type: path
+- condition: inputs.opName==RichardsonLucyC
+  customType: null
+  default: null
+  description: The maximum number of algorithm iterations
+  integer: null
+  key: inputs.maxIterations
+  number_range: null
+  title: maxIterations
+  ui_type: number
+version: 0.4.3

--- a/transforms/images/polus-imagej-deconvolve-richardsonlucytv-plugin/ict.yaml
+++ b/transforms/images/polus-imagej-deconvolve-richardsonlucytv-plugin/ict.yaml
@@ -1,0 +1,95 @@
+author:
+- Benjamin Houghton
+- Anjali Taneja
+citation: null
+contact: benjamin.houghton@axleinfo.com
+container: polusai/imagej-deconvolve-richardsonlucytv-plugin:0.4.2
+description: PadAndRichardsonLucyTV
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Op overloading method to perform
+  io_format:
+  - opName
+  io_type: string
+  name: opName
+  required: true
+- description: Collection to be processed by this plugin
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+- description: The point spread function mask to be used
+  io_format:
+  - psf
+  io_type: path
+  name: psf
+  required: true
+- description: The maximum number of algorithm iterations
+  io_format:
+  - maxIterations
+  io_type: number
+  name: maxIterations
+  required: true
+- description: The total variation regularization factor
+  io_format:
+  - regularizationFactor
+  io_type: number
+  name: regularizationFactor
+  required: true
+name: polusai/ImageJdeconvolverichardsonLucyTV
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: ImageJ deconvolve richardsonLucyTV
+ui:
+- condition: null
+  customType: null
+  description: Op overloading method to perform
+  fields:
+  - PadAndRichardsonLucyTV
+  key: inputs.opName
+  optional: null
+  title: opName
+  ui_type: select
+- condition: null
+  customType: null
+  description: Collection to be processed by this plugin
+  ext: null
+  key: inputs.inpDir
+  title: inpDir
+  ui_type: path
+- condition: null
+  customType: null
+  description: The point spread function mask to be used
+  ext: null
+  key: inputs.psf
+  title: psf
+  ui_type: path
+- condition: null
+  customType: null
+  default: null
+  description: The maximum number of algorithm iterations
+  integer: null
+  key: inputs.maxIterations
+  number_range: null
+  title: maxIterations
+  ui_type: number
+- condition: null
+  customType: null
+  default: null
+  description: The total variation regularization factor
+  integer: null
+  key: inputs.regularizationFactor
+  number_range: null
+  title: regularizationFactor
+  ui_type: number
+version: 0.4.2

--- a/transforms/images/polus-imagej-filter-addpoissonnoise-plugin/ict.yaml
+++ b/transforms/images/polus-imagej-filter-addpoissonnoise-plugin/ict.yaml
@@ -1,0 +1,53 @@
+author:
+- Nick Schaub
+- Anjali Taneja
+- Benjamin Houghton
+citation: null
+contact: nick.schaub@nih.gov
+container: polusai/imagej-filter-addpoissonnoise-plugin:0.4.4
+description: This plugin adds noise of a Poisson distribution to an input image.
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Op overloading method to perform
+  io_format:
+  - opName
+  io_type: string
+  name: opName
+  required: true
+- description: Collection to be processed by this plugin
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: false
+name: polusai/ImageJfilteraddPoissonNoise
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: ImageJ filter addPoissonNoise
+ui:
+- condition: null
+  customType: null
+  description: Op overloading method to perform
+  fields:
+  - AddPoissonNoiseMap
+  key: inputs.opName
+  optional: null
+  title: opName
+  ui_type: select
+- condition: inputs.opName==AddPoissonNoiseMap
+  customType: null
+  description: Collection to be processed by this plugin
+  ext: null
+  key: inputs.inpDir
+  title: inpDir
+  ui_type: path
+version: 0.4.4

--- a/transforms/images/polus-imagej-filter-convolve-plugin/ict.yaml
+++ b/transforms/images/polus-imagej-filter-convolve-plugin/ict.yaml
@@ -1,0 +1,69 @@
+author:
+- Benjamin Houghton
+- Anjali Taneja
+citation: null
+contact: benjamin.houghton@axleinfo.com
+container: polusai/imagej-filter-convolve-plugin:0.4.2
+description: This plugin applies a user specified convolutional kernel to an input
+  collection.
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Op overloading method to perform
+  io_format:
+  - opName
+  io_type: string
+  name: opName
+  required: true
+- description: Collection to be processed by this plugin
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+- description: The convolutional kernel to be applied to the collection
+  io_format:
+  - kernel
+  io_type: path
+  name: kernel
+  required: true
+name: polusai/ImageJfilterconvolve
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: ImageJ filter convolve
+ui:
+- condition: null
+  customType: null
+  description: Op overloading method to perform
+  fields:
+  - ConvolveNaiveF
+  - PadAndConvolveFFTF
+  - PadAndConvolveFFT
+  - ConvolveFFTC
+  key: inputs.opName
+  optional: null
+  title: opName
+  ui_type: select
+- condition: null
+  customType: null
+  description: Collection to be processed by this plugin
+  ext: null
+  key: inputs.inpDir
+  title: inpDir
+  ui_type: path
+- condition: null
+  customType: null
+  description: The convolutional kernel to be applied to the collection
+  ext: null
+  key: inputs.kernel
+  title: kernel
+  ui_type: path
+version: 0.4.2

--- a/transforms/images/polus-imagej-filter-correlate-plugin/ict.yaml
+++ b/transforms/images/polus-imagej-filter-correlate-plugin/ict.yaml
@@ -1,0 +1,83 @@
+author:
+- Benjamin Houghton
+citation: null
+contact: benjamin.houghton@axleinfo.com
+container: polusai/imagej-filter-correlate-plugin:0.4.2
+description: The plugin applies a correlation operation to an input image with a user
+  specified kernel
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Op overloading method to perform
+  io_format:
+  - opName
+  io_type: string
+  name: opName
+  required: false
+- description: Collection to be processed by this plugin
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+- description: Kernel to be applied to image in correlation operation
+  io_format:
+  - kernel
+  io_type: path
+  name: kernel
+  required: true
+- description: 'The number of pixels to pad to each side of the image in each dimension:
+    x,y'
+  io_format:
+  - borderSize
+  io_type: string
+  name: borderSize
+  required: true
+name: polusai/ImageJfiltercorrelate
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: ImageJ filter correlate
+ui:
+- condition: null
+  customType: null
+  description: Op overloading method to perform
+  fields:
+  - PadAndCorrelateFFT
+  - CorrelateFFTC
+  key: inputs.opName
+  optional: null
+  title: opName
+  ui_type: select
+- condition: null
+  customType: null
+  description: Collection to be processed by this plugin
+  ext: null
+  key: inputs.inpDir
+  title: inpDir
+  ui_type: path
+- condition: null
+  customType: null
+  description: Kernel to be applied to image in correlation operation
+  ext: null
+  key: inputs.kernel
+  title: kernel
+  ui_type: path
+- condition: null
+  customType: null
+  default: null
+  description: 'The number of pixels to pad to each side of the image in each dimension:
+    x,y'
+  key: inputs.borderSize
+  regex: null
+  title: borderSize
+  toolbar: null
+  ui_type: text
+version: 0.4.2

--- a/transforms/images/polus-imagej-filter-derivativegauss-plugin/ict.yaml
+++ b/transforms/images/polus-imagej-filter-derivativegauss-plugin/ict.yaml
@@ -1,0 +1,83 @@
+author:
+- Benjamin Houghton
+- Anjali Taneja
+- Nick Schaub
+citation: null
+contact: benjamin.houghton@axleinfo.com
+container: polusai/imagej-filter-derivativegauss-plugin:0.4.4
+description: 'This plugin applies the nth derivative of a Gaussian to an input collection. '
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Op overloading method to perform
+  io_format:
+  - opName
+  io_type: string
+  name: opName
+  required: true
+- description: Collection to be processed by this plugin
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: false
+- description: Array of nth derivatives of the Gaussians (x,y)
+  io_format:
+  - derivatives
+  io_type: array
+  name: derivatives
+  required: false
+- description: The standard deviation of the Gaussians
+  io_format:
+  - sigma
+  io_type: array
+  name: sigma
+  required: false
+name: polusai/ImageJfilterderivativeGauss
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: ImageJ filter derivativeGauss
+ui:
+- condition: null
+  customType: null
+  description: Op overloading method to perform
+  fields:
+  - DefaultDerivativeGauss
+  key: inputs.opName
+  optional: null
+  title: opName
+  ui_type: select
+- condition: inputs.opName==DefaultDerivativeGauss
+  customType: null
+  description: Collection to be processed by this plugin
+  ext: null
+  key: inputs.inpDir
+  title: inpDir
+  ui_type: path
+- condition: inputs.opName==DefaultDerivativeGauss
+  customType: null
+  default: null
+  description: Array of nth derivatives of the Gaussians (x,y)
+  key: inputs.derivatives
+  regex: null
+  title: derivatives
+  toolbar: null
+  ui_type: text
+- condition: inputs.opName==DefaultDerivativeGauss
+  customType: null
+  default: null
+  description: The standard deviation of the Gaussians
+  key: inputs.sigma
+  regex: null
+  title: sigma
+  toolbar: null
+  ui_type: text
+version: 0.4.4

--- a/transforms/images/polus-imagej-filter-dog-plugin/ict.yaml
+++ b/transforms/images/polus-imagej-filter-dog-plugin/ict.yaml
@@ -1,0 +1,113 @@
+author:
+- Benjamin Houghton
+citation: null
+contact: benjamin.houghton@axleinfo.com
+container: polusai/imagej-filter-dog-plugin:0.3.2
+description: This plugin applies the Difference of Gaussians algorithm to an input
+  collection.
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Operation to peform
+  io_format:
+  - opName
+  io_type: string
+  name: opName
+  required: true
+- description: The collection to be processed by this plugin
+  io_format:
+  - inpDIr
+  io_type: path
+  name: inpDIr
+  required: true
+- description: The standard deviation of the first Gaussian filter
+  io_format:
+  - sigma1
+  io_type: number
+  name: sigma1
+  required: false
+- description: The standard deviation of the second Gaussian filter
+  io_format:
+  - sigma2
+  io_type: number
+  name: sigma2
+  required: false
+- description: The standard deviations of the first Gaussian filter (x,y)
+  io_format:
+  - sigmas1
+  io_type: array
+  name: sigmas1
+  required: false
+- description: The standard deviations of the second Gaussian filter (x,y)
+  io_format:
+  - sigmas2
+  io_type: array
+  name: sigmas2
+  required: false
+name: polusai/ImageJfilterdog
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: ImageJ filter dog
+ui:
+- condition: null
+  customType: null
+  description: Operation to peform
+  fields:
+  - DoGSingleSigmas
+  - DoGVaryingSigmas
+  key: inputs.opName
+  optional: null
+  title: opName
+  ui_type: select
+- condition: null
+  customType: null
+  description: The collection to be processed by this plugin
+  ext: null
+  key: inputs.inpDIr
+  title: inpDIr
+  ui_type: path
+- condition: inputs.opName==DoGSingleSigmas
+  customType: null
+  default: null
+  description: The standard deviation of the first Gaussian filter
+  integer: null
+  key: inputs.sigma1
+  number_range: null
+  title: sigma1
+  ui_type: number
+- condition: inputs.opName==DoGSingleSigmas
+  customType: null
+  default: null
+  description: The standard deviation of the second Gaussian filter
+  integer: null
+  key: inputs.sigma2
+  number_range: null
+  title: sigma2
+  ui_type: number
+- condition: inputs.opName==DoGVaryingSigmas
+  customType: null
+  default: null
+  description: The standard deviations of the first Gaussian filter (x,y)
+  key: inputs.sigmas1
+  regex: null
+  title: sigmas1
+  toolbar: null
+  ui_type: text
+- condition: inputs.opName==DoGVaryingSigmas
+  customType: null
+  default: null
+  description: The standard deviations of the second Gaussian filter (x,y)
+  key: inputs.sigmas2
+  regex: null
+  title: sigmas2
+  toolbar: null
+  ui_type: text
+version: 0.3.2

--- a/transforms/images/polus-imagej-filter-frangivesselness-plugin/ict.yaml
+++ b/transforms/images/polus-imagej-filter-frangivesselness-plugin/ict.yaml
@@ -1,0 +1,86 @@
+author:
+- Nick Schaub
+- Anjali Taneja
+- Benjamin Houghton
+citation: null
+contact: nick.schaub@nih.gov
+container: polusai/imagej-filter-frangivesselness-plugin:0.4.2
+description: Applies the Frangi Vesselness filter to an input collection to highlight
+  vessel-like structures
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Operation to perform
+  io_format:
+  - opName
+  io_type: string
+  name: opName
+  required: true
+- description: Collection to be processed by this plugin
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+- description: The physical distance between data points in the  image, can vary for
+    each dimension of the image.
+  io_format:
+  - spacing
+  io_type: array
+  name: spacing
+  required: true
+- description: The Frangi scale parameter
+  io_format:
+  - scale
+  io_type: number
+  name: scale
+  required: true
+name: polusai/ImageJfilterfrangiVesselness
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: ImageJ filter frangiVesselness
+ui:
+- condition: null
+  customType: null
+  description: Operation to perform
+  fields:
+  - DefaultFrangi
+  key: inputs.opName
+  optional: null
+  title: opName
+  ui_type: select
+- condition: null
+  customType: null
+  description: Collection to be processed by this plugin
+  ext: null
+  key: inputs.inpDir
+  title: inpDir
+  ui_type: path
+- condition: null
+  customType: null
+  default: null
+  description: The physical distance between data points in the  image, can vary for
+    each dimension of the image.
+  key: inputs.spacing
+  regex: null
+  title: spacing
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  default: null
+  description: The Frangi scale parameter
+  integer: null
+  key: inputs.scale
+  number_range: null
+  title: scale
+  ui_type: number
+version: 0.4.2

--- a/transforms/images/polus-imagej-filter-gauss-plugin/ict.yaml
+++ b/transforms/images/polus-imagej-filter-gauss-plugin/ict.yaml
@@ -1,0 +1,82 @@
+author:
+- Benjamin Houghton
+citation: null
+contact: benjamin.houghton@axleinfo.com
+container: polusai/imagej-filter-gauss-plugin:0.3.2
+description: This plugin applies a Gaussian Convolutional filter to an input collection.
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Operation overloading method to perform
+  io_format:
+  - opName
+  io_type: string
+  name: opName
+  required: true
+- description: Collection to be processed by this plugin
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+- description: The standard deviation of the Gaussian filter, same in both dimensions.
+  io_format:
+  - sigma
+  io_type: number
+  name: sigma
+  required: false
+- description: The standard deviations of the Gaussian filters, (x,y)
+  io_format:
+  - sigmas
+  io_type: array
+  name: sigmas
+  required: false
+name: polusai/ImageJfiltergauss
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: ImageJ filter gauss
+ui:
+- condition: null
+  customType: null
+  description: Operation overloading method to perform
+  fields:
+  - GaussRAISingleSigma
+  - DefaultGaussRAI
+  key: inputs.opName
+  optional: null
+  title: opName
+  ui_type: select
+- condition: null
+  customType: null
+  description: Collection to be processed by this plugin
+  ext: null
+  key: inputs.inpDir
+  title: inpDir
+  ui_type: path
+- condition: inputs.opName==GaussRAISingleSigma
+  customType: null
+  default: null
+  description: The standard deviation of the Gaussian filter, same in both dimensions.
+  integer: null
+  key: inputs.sigma
+  number_range: null
+  title: sigma
+  ui_type: number
+- condition: inputs.opName==DefaultGaussRAI
+  customType: null
+  default: null
+  description: The standard deviations of the Gaussian filters, (x,y)
+  key: inputs.sigmas
+  regex: null
+  title: sigmas
+  toolbar: null
+  ui_type: text
+version: 0.3.2

--- a/transforms/images/polus-imagej-filter-partialderivative-plugin/ict.yaml
+++ b/transforms/images/polus-imagej-filter-partialderivative-plugin/ict.yaml
@@ -1,0 +1,66 @@
+author:
+- Benjamin Houghton
+citation: null
+contact: benjamin.houghton@axleinfo.com
+container: polusai/imagej-filter-partialderivative-plugin:0.3.5
+description: 'ImageJ op that applies partial derivative filter to input collection. '
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Op overloading method to perform.
+  io_format:
+  - opName
+  io_type: string
+  name: opName
+  required: false
+- description: Input image collection to be processed by this plugin
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: false
+- description: Dimension in which the partial derivative should be applied
+  io_format:
+  - dimension
+  io_type: number
+  name: dimension
+  required: false
+name: polusai/ImageJfilterpartialDerivative
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: ImageJ filter partialDerivative
+ui:
+- condition: null
+  customType: null
+  description: Op overloading method to perform.
+  fields:
+  - PartialDerivativeRAI
+  key: inputs.opName
+  optional: null
+  title: opName
+  ui_type: select
+- condition: inputs.opName==PartialDerivativeRAI
+  customType: null
+  description: Input image collection to be processed by this plugin
+  ext: null
+  key: inputs.inpDir
+  title: inpDir
+  ui_type: path
+- condition: inputs.opName==PartialDerivativeRAI
+  customType: null
+  default: null
+  description: Dimension in which the partial derivative should be applied
+  integer: null
+  key: inputs.dimension
+  number_range: null
+  title: dimension
+  ui_type: number
+version: 0.3.5

--- a/transforms/images/polus-imagej-filter-sobel-plugin/ict.yaml
+++ b/transforms/images/polus-imagej-filter-sobel-plugin/ict.yaml
@@ -1,0 +1,51 @@
+author:
+- Benjamin Houghton
+citation: null
+contact: benjamin.houghton@axleinfo.com
+container: polusai/imagej-sobel-plugin:0.3.2
+description: This plugin applies the Sobel operator to an input collection
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Op overloading method to perform
+  io_format:
+  - opName
+  io_type: string
+  name: opName
+  required: false
+- description: Collection to be processed by this plugin
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: false
+name: polusai/ImageJfiltersobel
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: ImageJ filter sobel
+ui:
+- condition: null
+  customType: null
+  description: Op overloading method to perform
+  fields:
+  - SobelRAI
+  key: inputs.opName
+  optional: null
+  title: opName
+  ui_type: select
+- condition: inputs.opName==SobelRAI
+  customType: null
+  description: Collection to be processed by this plugin
+  ext: null
+  key: inputs.inpDir
+  title: inpDir
+  ui_type: path
+version: 0.3.2

--- a/transforms/images/polus-imagej-filter-tubeness-plugin/ict.yaml
+++ b/transforms/images/polus-imagej-filter-tubeness-plugin/ict.yaml
@@ -1,0 +1,82 @@
+author:
+- Benjamin Houghton
+citation: null
+contact: benjamin.houghton@axleinfo.com
+container: polusai/imagej-filter-tubeness-plugin:0.3.8
+description: This plugin filters a collection to produce a score for how tube-like
+  each point in the image is.
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Op overloading method to perform
+  io_format:
+  - opName
+  io_type: string
+  name: opName
+  required: false
+- description: Input collection to be processed by this plugin
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: false
+- description: Desired scale in physical units
+  io_format:
+  - sigma
+  io_type: number
+  name: sigma
+  required: false
+- description: Physical pixel sizes in all dimensions
+  io_format:
+  - calibration
+  io_type: array
+  name: calibration
+  required: false
+name: polusai/ImageJfiltertubeness
+outputs:
+- description: Output directory
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: ImageJ filter tubeness
+ui:
+- condition: null
+  customType: null
+  description: Op overloading method to perform
+  fields:
+  - DefaultTubeness
+  key: inputs.opName
+  optional: null
+  title: opName
+  ui_type: select
+- condition: inputs.opName==DefaultTubeness
+  customType: null
+  description: Input collection to be processed by this plugin
+  ext: null
+  key: inputs.inpDir
+  title: inpDir
+  ui_type: path
+- condition: inputs.opName==DefaultTubeness
+  customType: null
+  default: null
+  description: Desired scale in physical units
+  integer: null
+  key: inputs.sigma
+  number_range: null
+  title: sigma
+  ui_type: number
+- condition: inputs.opName==DefaultTubeness
+  customType: null
+  default: null
+  description: Physical pixel sizes in all dimensions
+  key: inputs.calibration
+  regex: null
+  title: calibration
+  toolbar: null
+  ui_type: text
+version: 0.3.8

--- a/transforms/images/polus-imagej-image-integral-plugin/ict.yaml
+++ b/transforms/images/polus-imagej-image-integral-plugin/ict.yaml
@@ -1,0 +1,54 @@
+author:
+- Benjamin Houghton
+- Nick Schaub
+- Anjali Taneja
+citation: null
+contact: benjamin.houghton@axleinfo.com
+container: polusai/imagej-image-integral-plugin:0.3.2
+description: This plugin applies the image integral algorithm to an input collection.
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Op overloading method to perform
+  io_format:
+  - opName
+  io_type: string
+  name: opName
+  required: false
+- description: Collection to be processed by this plugin
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: false
+name: polusai/ImageJimageintegral
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: ImageJ image integral
+ui:
+- condition: null
+  customType: null
+  description: Op overloading method to perform
+  fields:
+  - DefaultIntegralImg
+  - WrappedIntegralImg
+  key: inputs.opName
+  optional: null
+  title: opName
+  ui_type: select
+- condition: inputs.opName==WrappedIntegralImg
+  customType: null
+  description: Collection to be processed by this plugin
+  ext: null
+  key: inputs.inpDir
+  title: inpDir
+  ui_type: path
+version: 0.3.2

--- a/transforms/images/polus-imagej-image-invert-plugin/ict.yaml
+++ b/transforms/images/polus-imagej-image-invert-plugin/ict.yaml
@@ -1,0 +1,52 @@
+author:
+- Benjamin Houghton
+citation: null
+contact: benjamin.houghton@axleinfo.com
+container: polusai/imagej-image-invert-plugin:0.4.0
+description: This plugin invert the pixels values of the input collection.
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Op overloading method to perform
+  io_format:
+  - opName
+  io_type: string
+  name: opName
+  required: true
+- description: Collection to be processed by this plugin
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+name: polusai/ImageJimageinvert
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: ImageJ image invert
+ui:
+- condition: null
+  customType: null
+  description: Op overloading method to perform
+  fields:
+  - InvertIIInteger
+  - InvertII
+  key: inputs.opName
+  optional: null
+  title: opName
+  ui_type: select
+- condition: null
+  customType: null
+  description: Collection to be processed by this plugin
+  ext: null
+  key: inputs.inpDir
+  title: inpDir
+  ui_type: path
+version: 0.4.0

--- a/transforms/images/polus-intensity-projection-plugin/ict.yaml
+++ b/transforms/images/polus-intensity-projection-plugin/ict.yaml
@@ -1,0 +1,53 @@
+author:
+- Gauhar Bains
+citation: null
+contact: gauhar.bains@labshare.org
+container: polusai/intensity-projection-plugin:0.1.9
+description: Calculate volumetric intensity projections
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Input image collection to be processed by this plugin
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+- description: Type of volumetric intensity projection
+  io_format:
+  - projectionType
+  io_type: string
+  name: projectionType
+  required: true
+name: polusai/IntensityProjectionPlugin
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: Intensity Projection Plugin
+ui:
+- condition: null
+  customType: null
+  description: Input image collection to be processed by this plugin
+  ext: null
+  key: inputs.inpDir
+  title: Input collection
+  ui_type: path
+- condition: null
+  customType: null
+  description: Type of volumetric intensity projection
+  fields:
+  - max
+  - min
+  - mean
+  key: inputs.projectionType
+  optional: null
+  title: Projection Type
+  ui_type: select
+version: 0.1.9

--- a/transforms/images/polus-rolling-ball-plugin/ict.yaml
+++ b/transforms/images/polus-rolling-ball-plugin/ict.yaml
@@ -1,0 +1,65 @@
+author:
+- Najib Ishaq
+citation: null
+contact: najib.ishaq@axleinfo.com
+container: polusai/rolling-ball-plugin:1.0.2
+description: A WIPP plugin to perform background subtraction using the rolling-ball
+  algorithm.
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Input image collection to be processed by this plugin.
+  io_format:
+  - inputDir
+  io_type: path
+  name: inputDir
+  required: true
+- description: Radius of the ball used to perform background subtraction.
+  io_format:
+  - ballRadius
+  io_type: number
+  name: ballRadius
+  required: false
+- description: Whether the images have a light or dark background.
+  io_format:
+  - lightBackground
+  io_type: boolean
+  name: lightBackground
+  required: false
+name: polusai/RollingBall
+outputs:
+- description: Output collection
+  io_format:
+  - outputDir
+  io_type: path
+  name: outputDir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: Rolling Ball
+ui:
+- condition: null
+  customType: null
+  description: Input image collection to be processed by this plugin.
+  ext: null
+  key: inputs.inputDir
+  title: Input collection
+  ui_type: path
+- condition: null
+  customType: null
+  default: 25
+  description: Radius of the ball used to perform background subtraction.
+  integer: null
+  key: inputs.ballRadius
+  number_range: null
+  title: Ball Radius
+  ui_type: number
+- condition: null
+  customType: null
+  default: false
+  description: Whether the images have a light or dark background.
+  key: inputs.lightBackground
+  title: Light Background
+  ui_type: checkbox
+version: 1.0.2

--- a/transforms/images/polus-stack-z-slice-plugin/ict.yaml
+++ b/transforms/images/polus-stack-z-slice-plugin/ict.yaml
@@ -1,0 +1,51 @@
+author:
+- Nick Schaub
+citation: null
+contact: nick.schaub@nih.gov
+container: polusai/stack-z-slice-plugin:1.2.4
+description: Use a file name pattern to stack individual z-slices into a single image.
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Input collection
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+- description: File pattern for stacking slices...
+  io_format:
+  - filePattern
+  io_type: string
+  name: filePattern
+  required: true
+name: polusai/StackZ-slicesintoasingletiledtifffile
+outputs:
+- description: Output data for the plugin
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: Stack Z-slices into a single tiled tiff file
+ui:
+- condition: null
+  customType: null
+  description: Collection name...
+  ext: null
+  key: inputs.inpDir
+  title: 'Input collection: '
+  ui_type: path
+- condition: null
+  customType: null
+  default: null
+  description: File pattern for stacking slices.
+  key: inputs.filePattern
+  regex: null
+  title: 'File pattern: '
+  toolbar: null
+  ui_type: text
+version: 1.2.4

--- a/transforms/images/remove-border-objects-plugin/ict.yaml
+++ b/transforms/images/remove-border-objects-plugin/ict.yaml
@@ -1,0 +1,52 @@
+author:
+- Hamdah Shafqat
+citation: null
+contact: hamdah.abbasi@axleinfo.com
+container: polusai/remove-border-objects-plugin:0.1.1
+description: Remove border objects plugin clear objects which touch image borders
+  and squentially relabelling of image objects
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Input image collection to be processed by this plugin
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+- description: Filepattern to parse image files
+  io_format:
+  - pattern
+  io_type: string
+  name: pattern
+  required: false
+name: polusai/Removeborderobjects
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/PolusAI/polus-plugins
+specVersion: 1.0.0
+title: Remove border objects
+ui:
+- condition: null
+  customType: null
+  description: Input image collection
+  ext: null
+  key: inputs.inpDir
+  title: Input Image collection
+  ui_type: path
+- condition: null
+  customType: null
+  default: null
+  description: Filepattern to parse image files
+  key: inputs.pattern
+  regex: null
+  title: Pattern
+  toolbar: null
+  ui_type: text
+version: 0.1.1

--- a/transforms/images/roi-relabel-tool/ict.yaml
+++ b/transforms/images/roi-relabel-tool/ict.yaml
@@ -1,0 +1,56 @@
+author:
+- Najib Ishaq
+citation: null
+contact: najib.ishaq@nih.gov
+container: polusai/roi-relabel-tool:0.2.5-dev0
+description: Methods for relabeling and consolidating regions of interest (RoIs) in
+  a segmented or hand-labeled image.
+documentation: null
+entrypoint: python3 -m polus.images.transforms.images.roi_relabel
+hardware: null
+inputs:
+- description: Input image collection to be processed by this plugin.
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+- description: What operation to perform on the images.
+  io_format:
+  - method
+  io_type: string
+  name: method
+  required: false
+name: polusai/RoIRelabel
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/PolusAI/polus-plugins/transforms/images/roi-relabeling-plugin
+specVersion: 1.0.0
+title: RoI Relabel
+ui:
+- condition: null
+  customType: null
+  description: Input image collection to be processed by this plugin.
+  ext: null
+  key: inputs.inpDir
+  title: Input collection
+  ui_type: path
+- condition: null
+  customType: null
+  description: What operation to perform on the images.
+  fields:
+  - contiguous
+  - randomize
+  - randomByte
+  - graphColoring
+  - optimizedGraphColoring
+  key: inputs.method
+  optional: null
+  title: Method
+  ui_type: select
+version: 0.2.5-dev0

--- a/transforms/polus-recycle-vector-plugin/ict.yaml
+++ b/transforms/polus-recycle-vector-plugin/ict.yaml
@@ -1,0 +1,64 @@
+author:
+- Nick Schaub
+citation: null
+contact: nick.schaub@nih.gov
+container: polusai/recycle-vector-plugin:1.5.0
+description: Apply existing stitching vector to an image collection.
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Stitching Vector.
+  io_format:
+  - stitchDir
+  io_type: path
+  name: stitchDir
+  required: true
+- description: Image Collection.
+  io_format:
+  - collectionDir
+  io_type: path
+  name: collectionDir
+  required: true
+- description: Filepattern to select files for vector recycling.
+  io_format:
+  - filepattern
+  io_type: string
+  name: filepattern
+  required: true
+name: polusai/RecycleExistingStitchingVector
+outputs:
+- description: Output stitching vector.
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: Recycle Existing Stitching Vector
+ui:
+- condition: null
+  customType: null
+  description: Stitching vector to recycle
+  ext: null
+  key: inputs.stitchDir
+  title: 'Input stitching vector: '
+  ui_type: path
+- condition: null
+  customType: null
+  description: Image collection to apply stitching vector against
+  ext: null
+  key: inputs.collectionDir
+  title: 'Input image collection: '
+  ui_type: path
+- condition: null
+  customType: null
+  default: null
+  description: Filepattern to select files for vector recycling.
+  key: inputs.filepattern
+  regex: null
+  title: 'Filepattern: '
+  toolbar: null
+  ui_type: text
+version: 1.5.0

--- a/transforms/tabular/polus-csv-merger-plugin/ict.yaml
+++ b/transforms/tabular/polus-csv-merger-plugin/ict.yaml
@@ -1,0 +1,80 @@
+author:
+- Nicholas Schaub
+citation: null
+contact: nick.schaub@nih.gov
+container: polusai/csv-merger-plugin:0.4.0
+description: Merge all csv files in a csv collection into a single csv file.
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Input image collection to be processed by this plugin
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+- description: Should csv be removed from the filename when indicating which file
+    a row in a csv file came from?
+  io_format:
+  - stripExtension
+  io_type: boolean
+  name: stripExtension
+  required: true
+- description: Merging dimension
+  io_format:
+  - dim
+  io_type: string
+  name: dim
+  required: true
+- description: Perform column merge on all files with the same number of rows?
+  io_format:
+  - sameRows
+  io_type: boolean
+  name: sameRows
+  required: true
+name: polusai/CSVMerger
+outputs:
+- description: Output csv file
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: CSV Merger
+ui:
+- condition: null
+  customType: null
+  description: Input image collection to be processed by this plugin
+  ext: null
+  key: inputs.inpDir
+  title: Input collection
+  ui_type: path
+- condition: null
+  customType: null
+  default: true
+  description: Should csv be removed from the filename when indicating which file
+    a row in a csv file came from?
+  key: inputs.stripExtension
+  title: Remove CSV Extension
+  ui_type: checkbox
+- condition: null
+  customType: null
+  description: Merge along rows or columns?
+  fields:
+  - rows
+  - columns
+  key: inputs.dim
+  optional: null
+  title: Merging dimension
+  ui_type: select
+- condition: inputs.dim=='columns'
+  customType: null
+  default: false
+  description: Merge only csvs with matching number of rows?
+  key: inputs.sameRows
+  title: 'Merge CSVs with equal rows:'
+  ui_type: checkbox
+version: 0.4.0

--- a/transforms/tabular/polus-generalized-linear-model-plugin/ict.yaml
+++ b/transforms/tabular/polus-generalized-linear-model-plugin/ict.yaml
@@ -1,0 +1,108 @@
+author:
+- Jayapriya Nagarajan
+citation: null
+contact: jayapriya.nagarajan@nih.gov
+container: polusai/generalized-linear-model-plugin:0.2.5
+description: Modeling the data using Generalized linear model.
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Input csv file collection
+  io_format:
+  - inpdir
+  io_type: path
+  name: inpdir
+  required: true
+- description: Enter the column to be predicted
+  io_format:
+  - predictcolumn
+  io_type: string
+  name: predictcolumn
+  required: true
+- description: Columns to be excluded from the dataset
+  io_format:
+  - exclude
+  io_type: string
+  name: exclude
+  required: false
+- description: Select either primary or interaction or second order effects for modeling
+  io_format:
+  - glmmethod
+  io_type: string
+  name: glmmethod
+  required: true
+- description: Select the family to be considered for modeling
+  io_format:
+  - modeltype
+  io_type: string
+  name: modeltype
+  required: true
+name: polusai/GeneralizedLinearModel
+outputs:
+- description: Output collection
+  io_format:
+  - outdir
+  io_type: path
+  name: outdir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: Generalized Linear Model
+ui:
+- condition: null
+  customType: null
+  description: Input csv file for modeling
+  ext: null
+  key: inputs.inpdir
+  title: Input csv file
+  ui_type: path
+- condition: null
+  customType: null
+  default: null
+  description: Enter the column name that needs to be predicted
+  key: inputs.predictcolumn
+  regex: null
+  title: Column to be predicted
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  default: null
+  description: Enter columns that need to be excluded
+  key: inputs.exclude
+  regex: null
+  title: Columns to be removed
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  description: Analyse either primaryfactors or interaction or second order effects
+    for modeling
+  fields:
+  - PrimaryFactors
+  - Interaction
+  - SecondOrder
+  key: inputs.glmmethod
+  optional: null
+  title: 'Select method type for modeling '
+  ui_type: select
+- condition: null
+  customType: null
+  description: Select either binomial or gaussian or Gamma or poisson or quasi or
+    quasibinomial or quasipoisson or negativebinomial or multinomial
+  fields:
+  - Binomial
+  - Gaussian
+  - Gamma
+  - Poisson
+  - NegativeBinomial
+  - Quasi
+  - Quasibinomial
+  - Quasipoisson
+  - Multinomial
+  key: inputs.modeltype
+  optional: null
+  title: Select the distribution to be considered for modeling
+  ui_type: select
+version: 0.2.5

--- a/transforms/tabular/polus-generalized-linear-model-plugin/plugin.json
+++ b/transforms/tabular/polus-generalized-linear-model-plugin/plugin.json
@@ -93,11 +93,6 @@
       "key": "inputs.modeltype",
       "title": "Select the distribution to be considered for modeling",
       "description": "Select either binomial or gaussian or Gamma or poisson or quasi or quasibinomial or quasipoisson or negativebinomial or multinomial"
-    },
-    {
-      "key": "inputs.outdir",
-      "title": "Output csv file",
-      "description": "Save output csv file containing summary of the glm model"
     }
   ]
 }

--- a/transforms/tabular/tabular-thresholding-tool/ict.yaml
+++ b/transforms/tabular/tabular-thresholding-tool/ict.yaml
@@ -1,0 +1,195 @@
+author:
+- Hamdah Shafqat
+- Najib Ishaq
+citation: null
+contact: hamdahshafqat.abbasi@nih.gov
+container: polusai/tabular-thresholding-tool:0.1.6-dev0
+description: This plugin computes thresholds using three methods and apply thresholds
+  on each labelled data to produce binary outputs
+documentation: null
+entrypoint: python3 -m polus.images.transforms.tabular.tabular_thresholding
+hardware: null
+inputs:
+- description: Directory containing tabular data
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+- description: Pattern to parse input files
+  io_format:
+  - filePattern
+  io_type: string
+  name: filePattern
+  required: false
+- description: FeatureName containing information about the position of non treated
+    wells
+  io_format:
+  - negControl
+  io_type: string
+  name: negControl
+  required: true
+- description: FeatureName containing information about the position of wells with
+    known treatment outcome
+  io_format:
+  - posControl
+  io_type: string
+  name: posControl
+  required: false
+- description: Name of the Variable for computing thresholds
+  io_format:
+  - varName
+  io_type: string
+  name: varName
+  required: true
+- description: Name of the threshold method
+  io_format:
+  - thresholdType
+  io_type: string
+  name: thresholdType
+  required: true
+- description: False positive rate threshold value
+  io_format:
+  - falsePositiverate
+  io_type: number
+  name: falsePositiverate
+  required: false
+- description: Number of Bins for otsu threshold
+  io_format:
+  - numBins
+  io_type: number
+  name: numBins
+  required: false
+- description: Number of Standard deviation
+  io_format:
+  - n
+  io_type: number
+  name: n
+  required: false
+- description: Output format
+  io_format:
+  - outFormat
+  io_type: string
+  name: outFormat
+  required: true
+name: polusai/tabular-thresholding-plugin
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/PolusAI/polus-plugins
+specVersion: 1.0.0
+title: tabular-thresholding-plugin
+ui:
+- condition: null
+  customType: null
+  description: Input directory containing tabular data
+  ext: null
+  key: inputs.inpDir
+  title: inpDir
+  ui_type: path
+- condition: null
+  customType: null
+  default: null
+  description: Pattern to parse input files
+  key: inputs.filePattern
+  regex: null
+  title: filePattern
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  default: null
+  description: FeatureName containing information about the position of non treated
+    wells
+  key: inputs.negControl
+  regex: null
+  title: negControl
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  default: null
+  description: FeatureName containing information about the position of wells with
+    known treatment outcome
+  key: inputs.posControl
+  regex: null
+  title: posControl
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  default: null
+  description: FeatureName containing information about the position of wells with
+    known treatment outcome
+  key: inputs.posControl
+  regex: null
+  title: posControl
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  default: null
+  description: Name of the Variable for computing thresholds
+  key: inputs.varName
+  regex: null
+  title: varName
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  description: Name of the threshold method
+  fields:
+  - fpr
+  - otsu
+  - nsigma
+  - all
+  key: inputs.thresholdType
+  optional: null
+  title: thresholdType
+  ui_type: select
+- condition: null
+  customType: null
+  default: 1.0
+  description: False positive rate threshold value
+  integer: null
+  key: inputs.falsePositiverate
+  number_range: null
+  title: falsePositiverate
+  ui_type: number
+- condition: null
+  customType: null
+  default: 512
+  description: Number of Bins for otsu threshold
+  integer: null
+  key: inputs.numBins
+  number_range: null
+  title: numBins
+  ui_type: number
+- condition: null
+  customType: null
+  default: 4
+  description: Number of Standard deviation
+  integer: null
+  key: inputs.n
+  number_range: null
+  title: n
+  ui_type: number
+- condition: null
+  customType: null
+  description: Output format
+  fields:
+  - .csv
+  - .feather
+  - .parquet
+  - .hdf5
+  - .arrow
+  - default
+  key: inputs.outFormat
+  optional: null
+  title: outFormat
+  ui_type: select
+version: 0.1.6-dev0

--- a/utils/filepattern-generator-plugin/ict.yaml
+++ b/utils/filepattern-generator-plugin/ict.yaml
@@ -1,0 +1,85 @@
+author:
+- Nick Schaub
+- Hamdah Shafqat
+- Kevin Hannon
+citation: null
+contact: nick.schaub@nih.gov
+container: polusai/filepattern-generator-plugin:0.2.1
+description: Filepattern Generator plugin creates a csv or feather file containing
+  a number of new filepatterns, where each filepattern will subset the data in the
+  directory
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Input image collection to be processed by this plugin
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+- description: Filepattern to parse image files
+  io_format:
+  - pattern
+  io_type: string
+  name: pattern
+  required: false
+- description: Number of images to generate collective filepattern
+  io_format:
+  - chunkSize
+  io_type: number
+  name: chunkSize
+  required: false
+- description: Select a parameter to generate filepatterns in specific order
+  io_format:
+  - groupBy
+  io_type: string
+  name: groupBy
+  required: false
+name: polusai/FilepatternGenerator
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/PolusAI/polus-plugins
+specVersion: 1.0.0
+title: Filepattern Generator
+ui:
+- condition: null
+  customType: null
+  description: Input image collection
+  ext: null
+  key: inputs.inpDir
+  title: Input Image collection
+  ui_type: path
+- condition: null
+  customType: null
+  default: null
+  description: Filepattern to parse image files
+  key: inputs.pattern
+  regex: null
+  title: Pattern
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  default: null
+  description: Number of images to generate collective filepattern
+  integer: null
+  key: inputs.chunkSize
+  number_range: null
+  title: chunkSize
+  ui_type: number
+- condition: null
+  customType: null
+  default: null
+  description: Select a parameter to generate filepatterns in specific order
+  key: inputs.groupBy
+  regex: null
+  title: groupBy
+  toolbar: null
+  ui_type: text
+version: 0.2.1

--- a/utils/polus-csv-collection-merger/ict.yaml
+++ b/utils/polus-csv-collection-merger/ict.yaml
@@ -1,0 +1,76 @@
+author:
+- Konstantin taletskiy
+citation: null
+contact: konstantin.taletskiy@labshare.org
+container: polusai/csv-collection-merger:0.1.2
+description: Merge two csv collections. You have an option to prepend collection name
+  to avoid name conflicts.
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Input csv collection A.
+  io_format:
+  - input-collection-a
+  io_type: path
+  name: input-collection-a
+  required: true
+- description: Append collection name to collection A.
+  io_format:
+  - append-a
+  io_type: boolean
+  name: append-a
+  required: false
+- description: Input csv collection B.
+  io_format:
+  - input-collection-b
+  io_type: path
+  name: input-collection-b
+  required: true
+- description: Append collection name to collection B.
+  io_format:
+  - append-b
+  io_type: boolean
+  name: append-b
+  required: false
+name: polusai/CSVcollectionsmerger
+outputs:
+- description: Output csv collection for the plugin
+  io_format:
+  - output
+  io_type: path
+  name: output
+  required: true
+repository: https://github.com/polusai/image-tools
+specVersion: 1.0.0
+title: CSV collections merger
+ui:
+- condition: null
+  customType: null
+  description: Pick a collection...
+  ext: null
+  key: inputs.input-collection-a
+  title: 'CSV Collection A: '
+  ui_type: path
+- condition: null
+  customType: null
+  default: null
+  description: Pick an option...
+  key: inputs.append-a
+  title: 'Append collection name to filenames in A: '
+  ui_type: checkbox
+- condition: null
+  customType: null
+  description: Pick a collection...
+  ext: null
+  key: inputs.input-collection-b
+  title: 'CSV Collection B: '
+  ui_type: path
+- condition: null
+  customType: null
+  default: null
+  description: Pick an option...
+  key: inputs.append-b
+  title: 'Append collection name to filenames in B: '
+  ui_type: checkbox
+version: 0.1.2

--- a/utils/polus-generic-to-image-collection-plugin/ict.yaml
+++ b/utils/polus-generic-to-image-collection-plugin/ict.yaml
@@ -1,0 +1,37 @@
+author:
+- Nick Schaub
+citation: null
+contact: nick.schaub@nih.gov
+container: polusai/generic-to-image-collection-plugin:0.1.1
+description: Copies .ome.tif files with proper tile format from a generic data type
+  to an image collection.
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Input image collection to be processed by this plugin
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+name: polusai/GenerictoImageCollection
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: Generic to Image Collection
+ui:
+- condition: null
+  customType: null
+  description: Input image collection to be processed by this plugin
+  ext: null
+  key: inputs.inpDir
+  title: Input collection
+  ui_type: path
+version: 0.1.1

--- a/utils/polus-imagej-macro-plugin/ict.yaml
+++ b/utils/polus-imagej-macro-plugin/ict.yaml
@@ -1,0 +1,65 @@
+author:
+- Benjamin Houghton
+citation: null
+contact: benjamin.houghton@axleinfo.com
+container: polusai/imagej-macro-plugin:0.1.3
+description: This plugin runs any ImageJ macro which inputs an image and outputs an
+  image.
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Collection to be processed by this plugin
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+- description: The macro directory to run on the input collection
+  io_format:
+  - macroDir
+  io_type: path
+  name: macroDir
+  required: true
+- description: The maximum number of macro attempts
+  io_format:
+  - maxIterations
+  io_type: number
+  name: maxIterations
+  required: false
+name: polusai/ImageJMacroPlugin
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/PolusAI/polus-plugins
+specVersion: 1.0.0
+title: ImageJ Macro Plugin
+ui:
+- condition: null
+  customType: null
+  description: Collection to be processed by this plugin
+  ext: null
+  key: inputs.inpDir
+  title: inpDir
+  ui_type: path
+- condition: null
+  customType: null
+  description: The macro to run on the input collection
+  ext: null
+  key: inputs.macroDir
+  title: macro
+  ui_type: path
+- condition: null
+  customType: null
+  default: null
+  description: The maximum number of macro attempts
+  integer: null
+  key: inputs.maxIterations
+  number_range: null
+  title: maxIterations
+  ui_type: number
+version: 0.1.3

--- a/utils/polus-stitching-vector-merger-plugin/ict.yaml
+++ b/utils/polus-stitching-vector-merger-plugin/ict.yaml
@@ -1,0 +1,88 @@
+author:
+- Gauhar Bains
+citation: null
+contact: gauhar.bains@labshare.org
+container: polusai/stitching-vector-merger-plugin:0.1.8
+description: This plugin merges stitching vector collections
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: 1st stitchingVector Collection
+  io_format:
+  - VectorCollection1
+  io_type: path
+  name: VectorCollection1
+  required: true
+- description: 2nd stitchingVector Collection
+  io_format:
+  - VectorCollection2
+  io_type: path
+  name: VectorCollection2
+  required: true
+- description: 3rd stitchingVector Collection
+  io_format:
+  - VectorCollection3
+  io_type: path
+  name: VectorCollection3
+  required: false
+- description: 4th stitchingVector Collection
+  io_format:
+  - VectorCollection4
+  io_type: path
+  name: VectorCollection4
+  required: false
+- description: 5th stitchingVector Collection
+  io_format:
+  - VectorCollection5
+  io_type: path
+  name: VectorCollection5
+  required: false
+name: polusai/MergeStitchingVector
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: Merge StitchingVector
+ui:
+- condition: null
+  customType: null
+  description: 1st stitchingVector Collection
+  ext: null
+  key: inputs.VectorCollection1
+  title: Stitching Vector Collection 1
+  ui_type: path
+- condition: null
+  customType: null
+  description: 2nd stitchingVector Collection
+  ext: null
+  key: inputs.VectorCollection2
+  title: Stitching Vector Collection 2
+  ui_type: path
+- condition: null
+  customType: null
+  description: 3rd stitchingVector Collection
+  ext: null
+  key: inputs.VectorCollection3
+  title: Stitching Vector Collection 3
+  ui_type: path
+- condition: null
+  customType: null
+  description: 4th stitchingVector Collection
+  ext: null
+  key: inputs.VectorCollection4
+  title: Stitching Vector Collection 4
+  ui_type: path
+- condition: null
+  customType: null
+  description: 5th stitchingVector Collection
+  ext: null
+  key: inputs.VectorCollection5
+  title: Stitching Vector Collection 5
+  ui_type: path
+version: 0.1.8

--- a/utils/polus-subset-data-plugin/ict.yaml
+++ b/utils/polus-subset-data-plugin/ict.yaml
@@ -1,0 +1,51 @@
+author:
+- Nick Schaub
+citation: null
+contact: nick.schaub@nih.gov
+container: polusai/subset-data-plugin:0.1.2
+description: Create a new image collection that is a subset of an existing image collection.
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Filename pattern used to separate data
+  io_format:
+  - filePattern
+  io_type: string
+  name: filePattern
+  required: true
+- description: Input image collection to be processed by this plugin
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+name: polusai/SubsetData
+outputs:
+- description: Output collection
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: Subset Data
+ui:
+- condition: null
+  customType: null
+  default: null
+  description: Filename pattern used to separate data
+  key: inputs.filePattern
+  regex: null
+  title: Filename pattern
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  description: Input image collection to be processed by this plugin
+  ext: null
+  key: inputs.inpDir
+  title: Input collection
+  ui_type: path
+version: 0.1.2

--- a/utils/rxiv-download-tool/ict.yaml
+++ b/utils/rxiv-download-tool/ict.yaml
@@ -1,0 +1,67 @@
+author:
+- Nick Schaub
+- Hamdah Shafqat
+citation: null
+contact: nick.schaub@nih.gov
+container: polusai/rxiv-download-tool:0.1.0-dev0
+description: This plugin allows to download data from Rxiv website.
+documentation: null
+entrypoint: python3 -m polus.images.utils.rxiv_download
+hardware: null
+inputs:
+- description: Pull records from open access archives.
+  io_format:
+  - rxiv
+  io_type: string
+  name: rxiv
+  required: true
+- description: Start date.
+  io_format:
+  - start
+  io_type: string
+  name: start
+  required: false
+- description: Generate an output preview.
+  io_format:
+  - preview
+  io_type: boolean
+  name: preview
+  required: false
+name: polusai/DownloadRxivtextdata
+outputs:
+- description: Output collection.
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/PolusAI/image-tools
+specVersion: 1.0.0
+title: Download Rxiv text data
+ui:
+- condition: null
+  customType: null
+  default: null
+  description: Pull records from open access archives.
+  key: inputs.rxiv
+  regex: null
+  title: rxiv
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  default: null
+  description: Start date.
+  key: inputs.start
+  regex: null
+  title: start
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  default: null
+  description: Generate an output preview.
+  key: inputs.preview
+  title: Preview example output of this plugin
+  ui_type: checkbox
+version: 0.1.0-dev0

--- a/utils/rxiv-download-tool/plugin.json
+++ b/utils/rxiv-download-tool/plugin.json
@@ -14,51 +14,57 @@
     "-m",
     "polus.images.utils.rxiv_download"
   ],
-  "inputs": {
-    "rxiv": {
+  "inputs": [
+    {
+      "name": "rxiv",
       "type": "string",
       "title": "rxiv",
       "description": "Pull records from open access archives.",
       "required": "True"
     },
-    "start": {
+    {
+      "name": "start",
       "type": "string",
       "title": "start",
       "description": "Start date.",
       "required": "False"
     },
-    "preview": {
+    {
+      "name": "preview",
       "type": "boolean",
       "title": "Preview",
       "description": "Generate an output preview.",
       "required": "False"
     }
-  },
-  "outputs": {
-    "outDir": {
+  ],
+  "outputs": [
+    {
       "name": "outDir",
       "type": "genericData",
       "description": "Output collection."
     }
-  },
-  "ui": {
-    "rxiv": {
+  ],
+  "ui": [
+    {
+      "key": "inputs.rxiv",
       "type": "string",
       "title": "rxiv",
       "description": "Pull records from open access archives.",
       "required": "True"
     },
-    "start": {
+    {
+      "key": "inputs.start",
       "type": "string",
       "title": "start",
       "description": "Start date.",
       "required": "False"
     },
-    "preview": {
+    {
+      "key": "inputs.preview",
       "type": "boolean",
       "title": "Preview example output of this plugin",
       "description": "Generate an output preview.",
       "required": "False"
     }
-  }
+  ]
 }

--- a/visualization/microjson-to-ome-tool/ict.yaml
+++ b/visualization/microjson-to-ome-tool/ict.yaml
@@ -1,0 +1,65 @@
+author:
+- Hamdah Shafqat
+citation: null
+contact: hamdahshafqat.abbasi@nih.gov
+container: polusai/microjson-to-ome-tool:0.1.5-dev0
+description: This plugin reconstruct binary images using polygon coordinates (rectangle,
+  encodings) of objects from microjson file.
+documentation: null
+entrypoint: python3 -m polus.images.visualization.microjson_to_ome
+hardware: null
+inputs:
+- description: Input image collection to be processed by this plugin.
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+- description: Filename pattern used to separate data.
+  io_format:
+  - filePattern
+  io_type: string
+  name: filePattern
+  required: false
+- description: Generate an output preview.
+  io_format:
+  - preview
+  io_type: boolean
+  name: preview
+  required: false
+name: polusai/Reconstructbinaryimageusingpolygoncoordinatesofobjects
+outputs:
+- description: Output collection.
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: Reconstruct binary image using polygon coordinates of objects
+ui:
+- condition: null
+  customType: null
+  description: Input image collection to be processed by this plugin.
+  ext: null
+  key: inputs.inpDir
+  title: Input collection
+  ui_type: path
+- condition: null
+  customType: null
+  default: null
+  description: Filename pattern used to separate data.
+  key: inputs.filePattern
+  regex: null
+  title: Filename pattern
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  default: null
+  description: Generate an output preview.
+  key: inputs.preview
+  title: Preview example output of this plugin
+  ui_type: checkbox
+version: 0.1.5-dev0

--- a/visualization/microjson-to-ome-tool/plugin.json
+++ b/visualization/microjson-to-ome-tool/plugin.json
@@ -14,50 +14,57 @@
     "-m",
     "polus.images.visualization.microjson_to_ome"
   ],
-  "inputs": {
-    "inpDir": {
+  "inputs": [
+    {
+      "name": "inpDir",
       "type": "genericData",
       "title": "Input collection",
       "description": "Input image collection to be processed by this plugin.",
       "required": "True"
     },
-    "filePattern": {
+    {
+      "name": "filePattern",
       "type": "string",
       "title": "Filename pattern",
       "description": "Filename pattern used to separate data.",
       "required": "False"
     },
-    "preview": {
+    {
+      "name": "preview",
       "type": "boolean",
       "title": "Preview",
       "description": "Generate an output preview.",
       "required": "False"
     }
-  },
-  "outputs": {
-    "outDir": {
+  ],
+  "outputs": [
+    {
+      "name": "outDir",
       "type": "collection",
       "description": "Output collection."
     }
-  },
-  "ui": {
-    "inpDir": {
+  ],
+  "ui": [
+    {
+      "key": "inputs.inpDir",
       "type": "genericData",
       "title": "Input collection",
       "description": "Input image collection to be processed by this plugin.",
       "required": "True"
     },
-    "filePattern": {
+    {
+      "key": "inputs.filePattern",
       "type": "string",
       "title": "Filename pattern",
       "description": "Filename pattern used to separate data.",
       "required": "False"
     },
-    "preview": {
+    {
+      "key": "inputs.preview",
       "type": "boolean",
       "title": "Preview example output of this plugin",
       "description": "Generate an output preview.",
       "required": "False"
     }
-  }
+  ]
 }

--- a/visualization/ome-to-microjson-tool/ict.yaml
+++ b/visualization/ome-to-microjson-tool/ict.yaml
@@ -1,0 +1,81 @@
+author:
+- Hamdah Shafqat
+citation: null
+contact: hamdahshafqat.abbasi@nih.gov
+container: polusai/ome-to-microjson-tool:0.1.5-dev0
+description: This plugin create a microjson of polygon coordinates (rectangle, encodings)
+  of binary segmentations.
+documentation: null
+entrypoint: python3 -m polus.images.visualization.ome_to_microjson
+hardware: null
+inputs:
+- description: Input image collection to be processed by this plugin.
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+- description: Filename pattern used to separate data.
+  io_format:
+  - filePattern
+  io_type: string
+  name: filePattern
+  required: false
+- description: Select polygon type from [rectangle, encoding].
+  io_format:
+  - polygonType
+  io_type: string
+  name: polygonType
+  required: true
+- description: Generate an output preview.
+  io_format:
+  - preview
+  io_type: boolean
+  name: preview
+  required: false
+name: polusai/Convertbinarysegmentationstomicojson
+outputs:
+- description: Output collection.
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: Convert binary segmentations to micojson
+ui:
+- condition: null
+  customType: null
+  description: Input image collection to be processed by this plugin.
+  ext: null
+  key: inputs.inpDir
+  title: Input collection
+  ui_type: path
+- condition: null
+  customType: null
+  default: null
+  description: Filename pattern used to separate data.
+  key: inputs.filePattern
+  regex: null
+  title: Filename pattern
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  description: Select polygon type from [rectangle, encoding].
+  fields:
+  - rectangle
+  - encoding
+  key: inputs.polygonType
+  optional: null
+  title: Type of Polygon
+  ui_type: select
+- condition: null
+  customType: null
+  default: null
+  description: Generate an output preview.
+  key: inputs.preview
+  title: Preview example output of this plugin
+  ui_type: checkbox
+version: 0.1.5-dev0

--- a/visualization/ome-to-microjson-tool/plugin.json
+++ b/visualization/ome-to-microjson-tool/plugin.json
@@ -14,20 +14,23 @@
     "-m",
     "polus.images.visualization.ome_to_microjson"
   ],
-  "inputs": {
-    "inpDir": {
+  "inputs": [
+    {
+      "name": "inpDir",
       "type": "collection",
       "title": "Input collection",
       "description": "Input image collection to be processed by this plugin.",
       "required": "True"
     },
-    "filePattern": {
+    {
+      "name": "filePattern",
       "type": "string",
       "title": "Filename pattern",
       "description": "Filename pattern used to separate data.",
       "required": "False"
     },
-    "polygonType": {
+    {
+      "name": "polygonType",
       "type": "enum",
       "title": "Type of Polygon",
       "description": "Select polygon type from [rectangle, encoding].",
@@ -39,44 +42,50 @@
       },
       "required": "True"
     },
-    "preview": {
+    {
+      "name": "preview",
       "type": "boolean",
       "title": "Preview",
       "description": "Generate an output preview.",
       "required": "False"
     }
-  },
-  "outputs": {
-    "outDir": {
+  ],
+  "outputs": [
+    {
+      "name": "outDir",
       "type": "collection",
       "description": "Output collection."
     }
-  },
-  "ui": {
-    "inpDir": {
+  ],
+  "ui": [
+    {
+      "key": "inputs.inpDir",
       "type": "collection",
       "title": "Input collection",
       "description": "Input image collection to be processed by this plugin.",
       "required": "True"
     },
-    "filePattern": {
+    {
+      "key": "inputs.filePattern",
       "type": "string",
       "title": "Filename pattern",
       "description": "Filename pattern used to separate data.",
       "required": "False"
     },
-    "polygonType": {
+    {
+      "key": "inputs.polygonType",
       "type": "enum",
       "title": "Type of Polygon",
       "description": "Select polygon type from [rectangle, encoding].",
       "default": "encoding",
       "required": "True"
     },
-    "preview": {
+    {
+      "key": "inputs.preview",
       "type": "boolean",
       "title": "Preview example output of this plugin",
       "description": "Generate an output preview.",
       "required": "False"
     }
-  }
+  ]
 }

--- a/visualization/polus-color-pyramid-builder-plugin/ict.yaml
+++ b/visualization/polus-color-pyramid-builder-plugin/ict.yaml
@@ -1,0 +1,126 @@
+author:
+- Nick Schaub
+citation: null
+contact: nick.schaub@nih.gov
+container: polusai/color-pyramid-builder-plugin:0.3.3
+description: Builds a DeepZoom color pyramid.
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Input image collection to be processed by this plugin
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+- description: Filename pattern used to separate data
+  io_format:
+  - filePattern
+  io_type: string
+  name: filePattern
+  required: true
+- description: Color ordering up to 7 colors (e.g. 1,11,,,,5,6)
+  io_format:
+  - layout
+  io_type: string
+  name: layout
+  required: true
+- description: Set bounds (should be float-float, int-int, or blank, e.g. 0.01-0.99,0-16000,,,,,)
+  io_format:
+  - bounds
+  io_type: string
+  name: bounds
+  required: false
+- description: If true, transparency is related to pixel intensity, where black is
+    fully transparent.
+  io_format:
+  - alpha
+  io_type: boolean
+  name: alpha
+  required: false
+- description: If stitching path is given, will assemble images in the collection
+    according to the stitching vector.
+  io_format:
+  - stitchPath
+  io_type: path
+  name: stitchPath
+  required: false
+- description: Gray level fill intensity. Ignored if stitchPath is undefined.
+  io_format:
+  - background
+  io_type: number
+  name: background
+  required: false
+name: polusai/ColorPyramidBuilder
+outputs:
+- description: Output pyramid path.
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: Color Pyramid Builder
+ui:
+- condition: null
+  customType: null
+  default: null
+  description: Filename pattern used to separate data
+  key: inputs.filePattern
+  regex: null
+  title: Filename pattern
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  description: Input image collection to be processed by this plugin
+  ext: null
+  key: inputs.inpDir
+  title: Input collection
+  ui_type: path
+- condition: null
+  customType: null
+  default: null
+  description: Color ordering (e.g. 1,11,,,,5,6)
+  key: inputs.layout
+  regex: null
+  title: Color layout
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  default: null
+  description: Set bounds (should be float-float, int-int, or blank, e.g. 0.01-0.99,0-16000,,,,,)
+  key: inputs.bounds
+  regex: null
+  title: Set rescaling bounds (optional)
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  default: null
+  description: If true, transparency is related to pixel intensity, where black is
+    fully transparent.
+  key: inputs.alpha
+  title: Make black transparent (optional)
+  ui_type: checkbox
+- condition: null
+  customType: null
+  description: If true, transparency is related to pixel intensity, where black is
+    fully transparent.
+  ext: null
+  key: inputs.stitchPath
+  title: Stitching Vector (optional)
+  ui_type: path
+- condition: null
+  customType: null
+  default: null
+  description: Gray level fill intensity from 0-1. Ignored if stitchPath is undefined.
+  integer: null
+  key: inputs.background
+  number_range: null
+  title: Background gray level (optional)
+  ui_type: number
+version: 0.3.3

--- a/visualization/polus-feature-heatmap-pyramid-plugin/ict.yaml
+++ b/visualization/polus-feature-heatmap-pyramid-plugin/ict.yaml
@@ -1,0 +1,90 @@
+author:
+- Nick Schaub
+citation: null
+contact: nick.schaub@nih.gov
+container: polusai/feature-heatmap-pyramid-plugin:0.2.0
+description: Build a heatmap pyramid for features values in a csv as an overlay for
+  another pyramid.
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: CSV collection containing features
+  io_format:
+  - features
+  io_type: path
+  name: features
+  required: true
+- description: Input image collection used to build a pyramid that this plugin will
+    make an overlay for
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+- description: Stitching vector used to buld the image pyramid.
+  io_format:
+  - vector
+  io_type: path
+  name: vector
+  required: true
+- description: Method used to create the heatmap
+  io_format:
+  - method
+  io_type: string
+  name: method
+  required: true
+- description: Store stitching vector in metadata instead of a stitching collection.
+  io_format:
+  - vectorInMetadata
+  io_type: boolean
+  name: vectorInMetadata
+  required: true
+name: polusai/FeatureHeatmapPyramid
+outputs:
+- description: Heatmap images
+  io_format:
+  - outImages
+  io_type: path
+  name: outImages
+  required: true
+- description: Heatmap vectors
+  io_format:
+  - outVectors
+  io_type: path
+  name: outVectors
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: Feature Heatmap Pyramid
+ui:
+- condition: null
+  customType: null
+  description: CSV collection containing features
+  ext: null
+  key: inputs.features
+  title: Features
+  ui_type: path
+- condition: null
+  customType: null
+  description: Input image collection used to build a pyramid that this plugin will
+    make an overlay for
+  ext: null
+  key: inputs.inpDir
+  title: Input collection
+  ui_type: path
+- condition: null
+  customType: null
+  description: Stitching vector used to buld the image pyramid.
+  ext: null
+  key: inputs.vector
+  title: Stitching Vector
+  ui_type: path
+- condition: null
+  customType: null
+  default: null
+  description: Store stitching vectors in metadata of the output image collection.
+  key: inputs.vectorInMetadata
+  title: Store stitching vector in collection metadata
+  ui_type: checkbox
+version: 0.2.0

--- a/visualization/polus-graph-pyramid-builder-plugin/ict.yaml
+++ b/visualization/polus-graph-pyramid-builder-plugin/ict.yaml
@@ -1,0 +1,75 @@
+author:
+- Madhuri Vihani
+- Nick Schaub
+citation: null
+contact: Madhuri.Vihani@nih.gov
+container: polusai/graph-pyramid-builder-plugin:1.3.8
+description: Generates heatmaps from the data in a csv and builds a DeepZoom pyramid
+  for visualization.
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Input collection
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+- description: The number of bins in each graph
+  io_format:
+  - bincount
+  io_type: string
+  name: bincount
+  required: true
+- description: The scale used to generate the graphs
+  io_format:
+  - scale
+  io_type: string
+  name: scale
+  required: false
+name: polusai/GraphPyramidBuilding
+outputs:
+- description: DeepZoom pyramid output
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: Graph Pyramid Building
+ui:
+- condition: null
+  customType: null
+  description: Collection name...
+  ext: null
+  key: inputs.inpDir
+  title: 'Input CSV collection: '
+  ui_type: path
+- condition: null
+  customType: null
+  description: The number of bins for each column of data, less than 255 and must
+    be even.
+  fields:
+  - '200'
+  - '150'
+  - '100'
+  - '50'
+  - '20'
+  key: inputs.bincount
+  optional: null
+  title: Bincount
+  ui_type: select
+- condition: null
+  customType: null
+  description: Create logarithmically scaled, linearly scaled, or both graphs
+  fields:
+  - linear
+  - log
+  - both
+  key: inputs.scale
+  optional: null
+  title: Scale
+  ui_type: select
+version: 1.3.8

--- a/visualization/polus-graph-pyramid-builder-plugin/plugin.json
+++ b/visualization/polus-graph-pyramid-builder-plugin/plugin.json
@@ -40,7 +40,9 @@
           "log",
           "both"
         ]
-      }
+      },
+      "description": "The scale used to generate the graphs",
+      "required": false
     }
   ],
   "outputs": [

--- a/visualization/polus-image-cluster-annotation-plugin/ict.yaml
+++ b/visualization/polus-image-cluster-annotation-plugin/ict.yaml
@@ -1,0 +1,65 @@
+author:
+- Jayapriya Nagarajan
+citation: null
+contact: jayapriya.nagarajan@nih.gov
+container: polusai/image-cluster-annotation-plugin:0.1.7
+description: Converts the original image as all zeros except at the borders which
+  contains the cluster id.
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Input image file collection
+  io_format:
+  - imgdir
+  io_type: path
+  name: imgdir
+  required: true
+- description: Input csv file collection
+  io_format:
+  - csvdir
+  io_type: path
+  name: csvdir
+  required: true
+- description: 'Enter border width:'
+  io_format:
+  - borderwidth
+  io_type: number
+  name: borderwidth
+  required: false
+name: polusai/Imageclusterannotation
+outputs:
+- description: Output image collection
+  io_format:
+  - outdir
+  io_type: path
+  name: outdir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: Image cluster annotation
+ui:
+- condition: null
+  customType: null
+  description: Input image file collection
+  ext: null
+  key: inputs.imgdir
+  title: Input image file
+  ui_type: path
+- condition: null
+  customType: null
+  description: Input csv file collection
+  ext: null
+  key: inputs.csvdir
+  title: Input csv file
+  ui_type: path
+- condition: null
+  customType: null
+  default: null
+  description: 'Enter border width:'
+  integer: null
+  key: inputs.borderwidth
+  number_range: null
+  title: Enter border width
+  ui_type: number
+version: 0.1.7

--- a/visualization/polus-precompute-volume-plugin/ict.yaml
+++ b/visualization/polus-precompute-volume-plugin/ict.yaml
@@ -1,0 +1,83 @@
+author:
+- Madhuri Vihani
+- Nicholas Schaub
+- Hythem Sidky
+citation: null
+contact: Madhuri.Vihani@nih.gov
+container: polusai/precompute-volume-plugin:0.4.8
+description: This plugin generates precomputed volumes and meshes for labelled data
+  to view in Neuroglancer
+documentation: null
+entrypoint: '[python3, main.py]'
+hardware: null
+inputs:
+- description: Input collection
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+- description: Image or Segmentation
+  io_format:
+  - imageType
+  io_type: string
+  name: imageType
+  required: true
+- description: Pattern of the images in Input
+  io_format:
+  - filePattern
+  io_type: string
+  name: filePattern
+  required: false
+- description: Create meshes
+  io_format:
+  - mesh
+  io_type: boolean
+  name: mesh
+  required: false
+name: polusai/WIPPWidget
+outputs:
+- description: Precomputed output
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/labshare/polus-plugins
+specVersion: 1.0.0
+title: WIPP Widget
+ui:
+- condition: null
+  customType: null
+  description: Collection name...
+  ext: null
+  key: inputs.inpDir
+  title: 'Input collection: '
+  ui_type: path
+- condition: null
+  customType: null
+  default: null
+  description: 'Pattern of images in input collection (image_r{rrr}_c{ccc}_z{zzz}.ome.tif). '
+  key: inputs.filePattern
+  regex: null
+  title: 'Image Pattern: '
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  description: Image or Segmentation?
+  fields:
+  - image
+  - segmentation
+  key: inputs.imageType
+  optional: null
+  title: 'Image Type: '
+  ui_type: select
+- condition: inputs.imageType==segmentation
+  customType: null
+  default: false
+  description: null
+  key: inputs.mesh
+  title: 'Create meshes: '
+  ui_type: checkbox
+version: 0.4.8

--- a/visualization/precompute-slide-tool/ict.yaml
+++ b/visualization/precompute-slide-tool/ict.yaml
@@ -1,0 +1,87 @@
+author:
+- Madhuri Vihani
+- Nick Schaub
+- Antoine Gerardin
+- Najib Ishaq
+citation: null
+contact: Madhuri.Vihani@nih.gov
+container: polusai/precompute-slide-tool:1.7.1-dev0
+description: Precomputes a plane series in DeepZoom, Neuroglancer, or OME Zarr format.
+documentation: null
+entrypoint: python3 -m polus.images.visualization.precompute_slide
+hardware: null
+inputs:
+- description: Input collection
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+- description: Build a DeepZoom, Neuroglancer, Zarr pyramid
+  io_format:
+  - pyramidType
+  io_type: string
+  name: pyramidType
+  required: true
+- description: Image is either Segmentation or Image
+  io_format:
+  - imageType
+  io_type: string
+  name: imageType
+  required: false
+- description: Pattern of the images in Input
+  io_format:
+  - filePattern
+  io_type: string
+  name: filePattern
+  required: false
+name: polusai/PrecomputeSlideViewer
+outputs:
+- description: Precomputed output
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/LabShare/polus-plugins
+specVersion: 1.0.0
+title: Precompute Slide Viewer
+ui:
+- condition: null
+  customType: null
+  description: Collection name...
+  ext: null
+  key: inputs.inpDir
+  title: 'Input collection: '
+  ui_type: path
+- condition: null
+  customType: null
+  description: Build a DeepZoom, Neuroglancer, or Zarr pyramid?
+  fields:
+  - DeepZoom
+  - Neuroglancer
+  - Zarr
+  key: inputs.pyramidType
+  optional: null
+  title: 'Pyramid Type: '
+  ui_type: select
+- condition: inputs.pyramidType==Neuroglancer
+  customType: null
+  description: Image or Segmentation?
+  fields:
+  - image
+  - segmentation
+  key: inputs.imageType
+  optional: null
+  title: 'Image Type: '
+  ui_type: select
+- condition: null
+  customType: null
+  default: null
+  description: 'Pattern of images in input collection (image_r{rrr}_c{ccc}_z{zzz}.ome.tif). '
+  key: inputs.filePattern
+  regex: null
+  title: 'Image Pattern: '
+  toolbar: null
+  ui_type: text
+version: 1.7.1-dev0

--- a/visualization/tabular-to-microjson-tool/ict.yaml
+++ b/visualization/tabular-to-microjson-tool/ict.yaml
@@ -1,0 +1,109 @@
+author:
+- Hamdah Shafqat
+citation: null
+contact: hamdahshafqat.abbasi@nih.gov
+container: polusai/tabular-to-microjson-tool:0.1.2-dev0
+description: Generates JSON from tabular data.
+documentation: null
+entrypoint: python3 -m polus.images.visualization.tabular_to_microjson
+hardware: null
+inputs:
+- description: Path to the input directory containing tabular data
+  io_format:
+  - inpDir
+  io_type: path
+  name: inpDir
+  required: true
+- description: Path to the input directory containing stitching vector
+  io_format:
+  - stitchDir
+  io_type: path
+  name: stitchDir
+  required: true
+- description: A filepattern, used to select tabular data to be converted
+  io_format:
+  - filePattern
+  io_type: string
+  name: filePattern
+  required: false
+- description: A filepattern, used to parse filenames in stitching vector
+  io_format:
+  - stitchPattern
+  io_type: string
+  name: stitchPattern
+  required: true
+- description: Variable to group filenames in stitching vector
+  io_format:
+  - groupBy
+  io_type: string
+  name: groupBy
+  required: false
+- description: Type of geometry coordinates
+  io_format:
+  - geometryType
+  io_type: string
+  name: geometryType
+  required: false
+name: polusai/TabularToMicrojson
+outputs:
+- description: Path to the output directory
+  io_format:
+  - outDir
+  io_type: path
+  name: outDir
+  required: true
+repository: https://github.com/PolusAI/polus-plugins
+specVersion: 1.0.0
+title: Tabular To Microjson
+ui:
+- condition: null
+  customType: null
+  description: Input generic data collection to be processed by this plugin
+  ext: null
+  key: inputs.inpDir
+  title: Input generic collection
+  ui_type: path
+- condition: null
+  customType: null
+  description: Input directory containing stitching vector
+  ext: null
+  key: inputs.stitchDir
+  title: Input stitchDir
+  ui_type: path
+- condition: null
+  customType: null
+  default: null
+  description: A filepattern, used to select tabular data
+  key: inputs.filePattern
+  regex: null
+  title: Filepattern
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  default: null
+  description: A filepattern, used to parse filenames in stitching vector
+  key: inputs.stitchPattern
+  regex: null
+  title: stitchPattern
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  default: null
+  description: Variable to group filenames in stitching vector
+  key: inputs.groupBy
+  regex: null
+  title: groupBy
+  toolbar: null
+  ui_type: text
+- condition: null
+  customType: null
+  default: null
+  description: Type of geometry coordinates
+  key: inputs.geometryType
+  regex: null
+  title: geometryType
+  toolbar: null
+  ui_type: text
+version: 0.1.2-dev0


### PR DESCRIPTION
*To be merged after #525*
This PR adds ICT specification files for *most* tools in the repo:
*OpenMP tools have validation errors that did not allow for ICT conversion* https://github.com/PolusAI/image-tools/issues/526

This PR also includes the script used to convert the Tools to ICT. It can be used as a CLI Application, with options `--alll, -a` to convert all and `--name, -n` to specify the name of the Tool to convert.
```bash
$ python3 to_ict.py --all
03/13/2024 11:17:36 PM - INFO - Found 108 manifests in /Users/camilovelezr/image-tools
03/13/2024 11:17:36 PM - INFO - all: True
 33%|███████████████▊                                | 34/103 [00:00<00:00, 338.40it/s]03/13/2024 11:17:36 
100%|███████████████████████████████████████████████| 103/103 [00:00<00:00, 321.20it/s]
03/13/2024 11:17:36 PM - INFO - Converted 103/103 plugins
$ python3 to_ict.py -n "roi-relabel-tool"
03/13/2024 11:13:35 PM - INFO - Found 108 manifests in /Users/camilovelezr/image-tools
03/13/2024 11:13:35 PM - INFO - name: roi-relabel-tool
03/13/2024 11:13:35 PM - INFO - all: False
03/13/2024 11:13:35 PM - INFO - Converted 1/1 plugins
```