### PR TITLE
use git lfs for pytest

### DIFF
--- a/.github/workflows/package-tests.yml
+++ b/.github/workflows/package-tests.yml
@@ -108,6 +108,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          lfs: true
       - name: Set up Python
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
Need to convert git lfs pointer objects to file objects for pytest


Tested via manually copying workflow files to mm-tools (will rebase and remove workflow files on PR)
https://github.com/misterbrandonwalker/mm-tools/actions/runs/9272319457/job/25509798379
